### PR TITLE
Changes psvDebugScreenPrintf from 512 limited buffer size to dynamic …

### DIFF
--- a/common/debugScreen.h
+++ b/common/debugScreen.h
@@ -154,15 +154,13 @@ int psvDebugScreenPuts(const char * text){
 }
 
 int psvDebugScreenPrintf(const char *format, ...) {
-	char buf[512];
-
-	va_list opt;
-	va_start(opt, format);
-	int ret = vsnprintf(buf, sizeof(buf), format, opt);
-	psvDebugScreenPuts(buf);
-	va_end(opt);
-
-	return ret;
+    char *buf;
+    va_list opt;
+    va_start(opt, format);
+    int ret = asprintf(&buf, format, opt);
+    psvDebugScreenPuts(buf);
+    va_end(opt);
+    return ret;
 }
 
 #endif


### PR DESCRIPTION
Just changed the vsprintf to asprintf since i thought it could be a nice idea to print no size limited strings for some debugging things