### PR TITLE
minor fix

### DIFF
--- a/socket_ping/CMakeLists.txt
+++ b/socket_ping/CMakeLists.txt
@@ -15,7 +15,7 @@ include("${VITASDK}/share/vita.cmake" REQUIRED)
 set(VITA_APP_NAME "Socket Ping")
 set(VITA_TITLEID  "VSDK00016")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 include_directories(

--- a/socket_ping/src/main.c
+++ b/socket_ping/src/main.c
@@ -74,7 +74,7 @@ void displayRecvPacket(char *recv_packet, uint32_t received_data, TcpHdr *tcphdr
 void displaySentPacket(char* packet, uint32_t packet_size, SceNetIcmpHeader *icmphdr, char *payload);
 
 
-int main (int *argc, char *argv[]){
+int main (int argc, char *argv[]){
 	char *packet; /* Packet to send */
 	char *payload; /* Payload inside packet */
 	int32_t retval; /* return value */
@@ -188,8 +188,6 @@ exit:
 
 
 uint16_t in_cksum(uint16_t *ptr, int32_t nbytes){
-	uint16_t swap;
-	uint32_t i;
 	uint32_t sum;
 	sum = 0;
 	while (nbytes > 1){


### PR DESCRIPTION
@devnoname120 : this is a minor fix, didn't have Wall flag set so warnings weren't showing.
- fixed `int *argc` to `int argc`
- removed unused vars
- changed cmakelists flag to -Wall
- todo: fix code so it follows strict-aliasing rules