### PR TITLE
FIX: DebugScreen Tab align

### DIFF
--- a/common/debugScreen.h
+++ b/common/debugScreen.h
@@ -20,6 +20,7 @@
 #define SCREEN_GLYPH_W  (8)
 #define SCREEN_GLYPH_H  (8)
 #define SCREEN_TAB_SIZE (4)
+#define SCREEN_TAB_W    (SCREEN_GLYPH_W * SCREEN_TAB_SIZE)
 
 #define COLOR_BLACK      0xFF000000
 #define COLOR_RED        0xFF0000FF
@@ -117,7 +118,7 @@ int psvDebugScreenPuts(const char * text){
 
 	for (c = 0; text[c] != '\0' ; c++) {
 		if (text[c] == '\t') {
-			psvDebugScreenCoordX = (psvDebugScreenCoordX + (SCREEN_GLYPH_W * (SCREEN_TAB_SIZE))) / (SCREEN_GLYPH_W * SCREEN_TAB_SIZE) * (SCREEN_GLYPH_W * SCREEN_TAB_SIZE);
+			psvDebugScreenCoordX += SCREEN_TAB_W - psvDebugScreenCoordX % SCREEN_TAB_W;
 			continue;
 		}
 		if (psvDebugScreenCoordX + 8 > SCREEN_WIDTH) {

--- a/common/debugScreen.h
+++ b/common/debugScreen.h
@@ -117,7 +117,7 @@ int psvDebugScreenPuts(const char * text){
 
 	for (c = 0; text[c] != '\0' ; c++) {
 		if (text[c] == '\t') {
-			psvDebugScreenCoordX += SCREEN_GLYPH_H * SCREEN_TAB_SIZE;
+			psvDebugScreenCoordX = (psvDebugScreenCoordX + (SCREEN_GLYPH_W * (SCREEN_TAB_SIZE))) / (SCREEN_GLYPH_W * SCREEN_TAB_SIZE) * (SCREEN_GLYPH_W * SCREEN_TAB_SIZE);
 			continue;
 		}
 		if (psvDebugScreenCoordX + 8 > SCREEN_WIDTH) {


### PR DESCRIPTION
This Fix will mimic the real terminal behavior.

see:

![](http://i.imgur.com/wizJA7d.png)
