### PR TITLE
New debugscreen implementation

### DIFF
--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+SCRIPTNAME='build.sh'
+RC=0
+if [ -n "${BASH:-}" ]; then
+  [ "${0}" = "${BASH_SOURCE}" ] || RC=1
+else
+  [ "$(basename -- "${0}")" = "${SCRIPTNAME}" ] || RC=1
+fi
+[ "${RC}" -eq 0 ] || {
+  printf -- 'Script cannot be sourced\n'
+  return 1 || exit 1
+}
+
+[ -d 'build' ] || mkdir build
+cd build
+cmake .. && make

--- a/camera/src/main.c
+++ b/camera/src/main.c
@@ -6,6 +6,7 @@
 #include <psp2/display.h>
 #include <psp2/ctrl.h>
 #include <psp2/camera.h>
+#include <psp2/kernel/processmgr.h>
 
 #define ARRAYSIZE(x) (sizeof(x)/sizeof(*x))
 #define DISPLAY_WIDTH 640

--- a/common/debugScreen.c
+++ b/common/debugScreen.c
@@ -118,10 +118,10 @@
 
 static int mutex, coordX, coordY;
 static int savedX[SAVE_STORAGES] = { 0 }, savedY[SAVE_STORAGES] = { 0 };
-static ColorState colors = { false, false, // truecolor flags
+static ColorState colors = { 0, 0, // truecolor flags
                              0, 0, // truecolors
-                             0, 0, 0, 0, false, // ANSI/VTERM/GREYSCALE colors
-                             7, 22, 0, 22, false, // default colors (ANSI/VTERM/GREYSCALE)
+                             0, 0, 0, 0, 0, // ANSI/VTERM/GREYSCALE colors
+                             7, 22, 0, 22, 0, // default colors (ANSI/VTERM/GREYSCALE)
                            };
 
 static PsvDebugScreenFont *psvDebugScreenFontCurrent = &psvDebugScreenFont;
@@ -187,7 +187,7 @@ static uint32_t ANSI_COLORS_BGR[256] = {
 * Reset foreground color to default
 */
 static void psvDebugScreenResetFgColor(void) {
-	colors.fgTrueColorFlag = false;
+	colors.fgTrueColorFlag = 0;
 	colors.fgTrueColor = 0;
 	colors.fgIndex = colors.fgIndexDefault;
 	colors.fgIntensity = colors.fgIntensityDefault;
@@ -197,7 +197,7 @@ static void psvDebugScreenResetFgColor(void) {
 * Reset background color to default
 */
 static void psvDebugScreenResetBgColor(void) {
-	colors.bgTrueColorFlag = false;
+	colors.bgTrueColorFlag = 0;
 	colors.bgTrueColor = 0;
 	colors.bgIndex = colors.bgIndexDefault;
 	colors.bgIntensity = colors.bgIntensityDefault;
@@ -267,7 +267,7 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 	unsigned int i, argc, arg[32] = { 0 };
 	unsigned int c;
 	uint32_t unit, mode;
-	bool *colorTrueColorFlag;
+	int *colorTrueColorFlag;
 	uint32_t *colorTrueColor;
 	unsigned char *colorIndex, *colorIntensity;
 	for (i = 0, argc = 0; (argc < (sizeof(arg)/sizeof(*arg))) && (str[i] != '\0'); i++) {
@@ -342,10 +342,10 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 							continue;
 						// inversion
 						case 7: // enable
-							colors.inversion = true;
+							colors.inversion = 1;
 							continue;
 						case 27: // disable
-							colors.inversion = false;
+							colors.inversion = 0;
 							continue;
 						// set from color map or truecolor
 						case 38: // foreground color
@@ -353,14 +353,14 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 							mode = arg[c] / 10;
 							colorTrueColorFlag = mode&1 ? &colors.fgTrueColorFlag : &colors.bgTrueColorFlag;
 							if (arg[c+1]==5) { // 8-bit: [0-15][16-231][232-255] color map
-								*colorTrueColorFlag = false;
+								*colorTrueColorFlag = 0;
 								colorIndex = mode&1 ? &colors.fgIndex : &colors.bgIndex;
 								*colorIndex = arg[c+2] & 0xFF;
 								colorIntensity = mode&1 ? &colors.fgIntensity : &colors.bgIntensity;
 								*colorIntensity = ((*colorIndex>=8) && (*colorIndex<=15)) ? 1 : 22;
 								c+=2; // extra arguments
 							} else if (arg[c+1]==2) { // 24-bit color space
-								*colorTrueColorFlag = true;
+								*colorTrueColorFlag = 1;
 								colorTrueColor = mode&1 ? &colors.fgTrueColor : &colors.bgTrueColor;
 								*colorTrueColor = FROM_FULL_RGB(arg[c+2], arg[c+3], arg[c+4]);
 								c+=4; // extra arguments
@@ -381,7 +381,7 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 							unit = arg[c] % 10;
 							if (unit>7) continue; // skip unsupported modes
 							colorTrueColorFlag = mode&1 ? &colors.fgTrueColorFlag : &colors.bgTrueColorFlag;
-							*colorTrueColorFlag = false;
+							*colorTrueColorFlag = 0;
 							colorIndex = mode&1 ? &colors.fgIndex : &colors.bgIndex;
 							*colorIndex = unit;
 							colorIntensity = mode&1 ? &colors.fgIntensity : &colors.bgIntensity;
@@ -476,9 +476,9 @@ int psvDebugScreenPuts(const char * _text) {
 		row = 0;
 		// check if glyph is available in font
 		if ((t > (F)->last) || (t < (F)->first)) {
-			drawDummy = true;
+			drawDummy = 1;
 		} else {
-			drawDummy = false;
+			drawDummy = 0;
 			bitmap_offset = (t - (F)->first) * bits_per_glyph;
 			font = &(F)->glyphs[ (bitmap_offset / 8) ];
 			mask = 1 << 7;

--- a/common/debugScreen.c
+++ b/common/debugScreen.c
@@ -1,0 +1,691 @@
+#ifndef DEBUG_SCREEN_C
+#define DEBUG_SCREEN_C
+
+/*
+* debugScreen.c of Vita SDK
+*
+* - psvDebugScreenInit()
+*    Initializes debug screen for output.
+*
+* - psvDebugScreenPuts()
+*    Similar to the C library function puts() writes a string to the debug
+*    screen up to but not including the NUL character.
+*    Supports the most important CSI sequences of ECMA-48 / ISO/IEC 6429:1992.
+*    Graphic Rendition Combination Mode (GRCM) supported is Cumulative.
+*    Modifications:
+*    - CSI SGR codes 30-37/38/39 & 40-47/48/49 set standard/fitting/default intensity, so instead of "\e[1;31m" use "\e31;1m"
+*    - ANSI color #8 is made darker (40<>80), so that "dark" white is still lighter than "bright" dark
+*    - support 16 save storages for CSI s and CSI u, e.g "\e[8s" and "\e[8u"
+*    [1] https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences
+*    [2] https://jonasjacek.github.io/colors/
+*    [3] https://www.ecma-international.org/publications/standards/Ecma-048.htm
+*    [4] https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+*    [5] http://man7.org/linux/man-pages/man4/console_codes.4.html
+*
+*    (CSI = "\e[")
+*     CSI [n] s   = Save Cursor Position to slot #n (0-15). Default 0.
+*     CSI [n] u   = Restore Cursor Position from slot #n (0-15). Default 0.
+*     CSI n A     = Cursor Up <n> times.
+*     CSI n B     = Cursor Down <n> times.
+*     CSI n C     = Cursor Forward <n> times.
+*     CSI n D     = Cursor Back <n> times.
+*     CSI n E     = Cursor Next Line <n> times and to Beginning of that Line.
+*     CSI n F     = Cursor Previous Line <n> times and to Beginning of that Line.
+*     CSI n G     = Cursor to Column <n>. The value is 1-based and defaults to 1 (first column) if omitted.
+*     CSI n ; m H = Cursor to Row <n> and Column <m>. The values are 1-based and default to 1 (top left corner) if omitted.
+*     CSI n ; m f = Cursor to Row <n> and Column <m>. The values are 1-based and default to 1 (top left corner) if omitted.
+*     CSI [n] J   = Clears part of the screen. Cursor position does not change.
+*                   0 (default) from cursor to end of screen.
+*                   1 from cursor to beginning of the screen.
+*                   2 entire screen
+*     CSI [n] K   = Clears part of the line. Cursor position does not change.
+*                   0 (default) from cursor to end of line.
+*                   1 from cursor to beginning of line.
+*                   2 clear entire line.
+*     CSI [n] m = Sets the appearance of the following characters.
+*               0       Reset all (colors and inversion) (default)
+*               1       Increased intensity ("bright" color)
+*               2       Decreased intensity ("faint"/"dark" color)
+*               7       Enable inversion
+*               22      Standard intensity ("normal" color)
+*               27      Disable inversion
+*               30–37   Set ANSI foreground color with standard intensity
+*               38      Set foreground color. Arguments are 5;<n> or 2;<r>;<g>;<b>
+*               39      Default foreground color
+*               40–47   Set standard ANSI background color with standard intensity
+*               48      Set background color. Arguments are 5;<n> or 2;<r>;<g>;<b>
+*               49      Default background color
+*               90–97   Set ANSI foreground color with increased intensity
+*               100–107 Set ANSI background color with increased intensity
+*
+* - psvDebugScreenPrintf()
+*    Similar to the C library function printf() formats a string and ouputs
+*    it via psvDebugScreenPuts() to the debug screen.
+*
+* - psvDebugScreenGetColorStateCopy(ColorState *copy)
+*    Get copy of current color state.
+*
+* - psvDebugScreenGetCoordsXY(int *x, int *y)
+*    Get copy of current pixel coordinates.
+*    Allows for multiple and custom position stores.
+*    Allows correct positioning when using different font sizes.
+*
+* - psvDebugScreenSetCoordsXY(int *x, int *y)
+*    Set pixel coordinates.
+*    Allows for multiple and custom position stores.
+*    Allows correct positioning when using different font sizes.
+*
+* - PsvDebugScreenFont *psvDebugScreenGetFont()
+*    Get current font.
+*
+* - PsvDebugScreenFont *psvDebugScreenSetFont(PsvDebugScreenFont *font) {
+*    Set font. Returns current font.
+*
+* - PsvDebugScreenFont *psvDebugScreenScaleFont2x(PsvDebugScreenFont *source_font) {
+*    Scales a font by 2 (e.g. 8x8 to 16x16) and returns new scaled font.
+*
+* Also see the following samples:
+* - debugscreen
+* - debug_print
+*
+*/
+
+#include <stdlib.h> // for malloc(), free()
+#include <stdio.h> // for vsnprintf()
+#include <string.h> // for memset(), memcpy()
+#include <stdarg.h> // for va_list, va_start(), va_end()
+#include <inttypes.h>
+
+#include "debugScreen.h"
+
+#include "debugScreenFont.c"
+
+#define SCREEN_FB_WIDTH (960) // frame buffer aligned width for accessing vram
+#define SCREEN_FB_SIZE  (2 * 1024 * 1024) // Must be 256KB aligned
+#ifndef SCREEN_TAB_SIZE // this allows easy overriding
+#define SCREEN_TAB_SIZE (8)
+#endif
+#define SCREEN_TAB_W    ((F)->size_w * (SCREEN_TAB_SIZE))
+#define F psvDebugScreenFontCurrent
+
+#define FROM_FULL_RGB(r,g,b ) ( ((b)<<16) | ((g)<<8) | (r) )
+#define CONVERT_RGB_BGR(rgb) rgb = ( (((rgb)&0x0000FF)<<16) | ((rgb)&0x00FF00) | (((rgb)&0xFF0000)>>16) )
+
+#define CLEARSCRNBLOCK(H,toH,W,toW,color) for (int h = (H); h < (toH); h++) for (int w = (W); w < (toW); w++) ((uint32_t*)base)[h*(SCREEN_FB_WIDTH) + w] = (color);
+#define CLEARSCRNLINES(H,toH,color) { uint32_t *pixel = (uint32_t *)base + ((H) * (SCREEN_FB_WIDTH)); int i = (((toH) - (H)) * (SCREEN_FB_WIDTH)); for (; i > 0; i--) *pixel++ = (color); }
+
+#define SAVE_STORAGES 16
+
+static int mutex, coordX, coordY;
+static int savedX[SAVE_STORAGES] = { 0 }, savedY[SAVE_STORAGES] = { 0 };
+static ColorState colors = { false, false, // truecolor flags
+                             0, 0, // truecolors
+                             0, 0, 0, 0, false, // ANSI/VTERM/GREYSCALE colors
+                             7, 22, 0, 22, false, // default colors (ANSI/VTERM/GREYSCALE)
+                           };
+
+static PsvDebugScreenFont *psvDebugScreenFontCurrent = &psvDebugScreenFont;
+
+#ifdef __vita__
+#include <psp2/display.h>
+#include <psp2/kernel/sysmem.h>
+#include <psp2/kernel/threadmgr.h>
+static void* base; // pointer to frame buffer
+#else
+#define NO_psvDebugScreenInit
+#ifndef psvDebugScreenInitReplacement
+#define psvDebugScreenInitReplacement(...)
+#endif
+#define sceKernelLockMutex(m,v,x) m=v
+#define sceKernelUnlockMutex(m,v) m=v
+static char base[(SCREEN_FB_WIDTH) * (SCREEN_HEIGHT) * 4];
+#endif
+
+static uint32_t DARK_COLORS_BGR[8] = {
+	0x000000, 0x000040, 0x004000, 0x004040, 0x400000, 0x400040, 0x404000, 0x808080, // 0-7
+};
+
+// ANSI/VTERM/GREYSCALE palette: https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+// modifications:
+// - #8 is made darker (40<>80), so that "dark" white is still lighter than "bright" dark
+static uint32_t ANSI_COLORS_BGR[256] = {
+	0x000000, 0x000080, 0x008000, 0x008080, 0x800000, 0x800080, 0x808000, 0xc0c0c0, // 0-7
+	0x404040, 0x0000ff, 0x00ff00, 0x00ffff, 0xff0000, 0xff00ff, 0xffff00, 0xffffff, // 8-15
+	0x000000, 0x5f0000, 0x870000, 0xaf0000, 0xd70000, 0xff0000, 0x005f00, 0x5f5f00, // 16-23
+	0x875f00, 0xaf5f00, 0xd75f00, 0xff5f00, 0x008700, 0x5f8700, 0x878700, 0xaf8700, // 24-31
+	0xd78700, 0xff8700, 0x00af00, 0x5faf00, 0x87af00, 0xafaf00, 0xd7af00, 0xffaf00, // 32-39
+	0x00d700, 0x5fd700, 0x87d700, 0xafd700, 0xd7d700, 0xffd700, 0x00ff00, 0x5fff00, // 40-47
+	0x87ff00, 0xafff00, 0xd7ff00, 0xffff00, 0x00005f, 0x5f005f, 0x87005f, 0xaf005f, // 48-55
+	0xd7005f, 0xff005f, 0x005f5f, 0x5f5f5f, 0x875f5f, 0xaf5f5f, 0xd75f5f, 0xff5f5f, // 56-63
+	0x00875f, 0x5f875f, 0x87875f, 0xaf875f, 0xd7875f, 0xff875f, 0x00af5f, 0x5faf5f, // 64-71
+	0x87af5f, 0xafaf5f, 0xd7af5f, 0xffaf5f, 0x00d75f, 0x5fd75f, 0x87d75f, 0xafd75f, // 72-79
+	0xd7d75f, 0xffd75f, 0x00ff5f, 0x5fff5f, 0x87ff5f, 0xafff5f, 0xd7ff5f, 0xffff5f, // 80-87
+	0x000087, 0x5f0087, 0x870087, 0xaf0087, 0xd70087, 0xff0087, 0x005f87, 0x5f5f87, // 88-95
+	0x875f87, 0xaf5f87, 0xd75f87, 0xff5f87, 0x008787, 0x5f8787, 0x878787, 0xaf8787, // 96-103
+	0xd78787, 0xff8787, 0x00af87, 0x5faf87, 0x87af87, 0xafaf87, 0xd7af87, 0xffaf87, // 104-111
+	0x00d787, 0x5fd787, 0x87d787, 0xafd787, 0xd7d787, 0xffd787, 0x00ff87, 0x5fff87, // 112-119
+	0x87ff87, 0xafff87, 0xd7ff87, 0xffff87, 0x0000af, 0x5f00af, 0x8700af, 0xaf00af, // 120-127
+	0xd700af, 0xff00af, 0x005faf, 0x5f5faf, 0x875faf, 0xaf5faf, 0xd75faf, 0xff5faf, // 128-135
+	0x0087af, 0x5f87af, 0x8787af, 0xaf87af, 0xd787af, 0xff87af, 0x00afaf, 0x5fafaf, // 136-143
+	0x87afaf, 0xafafaf, 0xd7afaf, 0xffafaf, 0x00d7af, 0x5fd7af, 0x87d7af, 0xafd7af, // 144-151
+	0xd7d7af, 0xffd7af, 0x00ffaf, 0x5fffaf, 0x87ffaf, 0xafffaf, 0xd7ffaf, 0xffffaf, // 152-159
+	0x0000d7, 0x5f00d7, 0x8700d7, 0xaf00d7, 0xd700d7, 0xff00d7, 0x005fd7, 0x5f5fd7, // 160-167
+	0x875fd7, 0xaf5fd7, 0xd75fd7, 0xff5fd7, 0x0087d7, 0x5f87d7, 0x8787d7, 0xaf87d7, // 168-175
+	0xd787d7, 0xff87d7, 0x00afd7, 0x5fafd7, 0x87afd7, 0xafafd7, 0xd7afd7, 0xffafd7, // 176-183
+	0x00d7d7, 0x5fd7d7, 0x87d7d7, 0xafd7d7, 0xd7d7d7, 0xffd7d7, 0x00ffd7, 0x5fffd7, // 184-191
+	0x87ffd7, 0xafffd7, 0xd7ffd7, 0xffffd7, 0x0000ff, 0x5f00ff, 0x8700ff, 0xaf00ff, // 192-199
+	0xd700ff, 0xff00ff, 0x005fff, 0x5f5fff, 0x875fff, 0xaf5fff, 0xd75fff, 0xff5fff, // 200-207
+	0x0087ff, 0x5f87ff, 0x8787ff, 0xaf87ff, 0xd787ff, 0xff87ff, 0x00afff, 0x5fafff, // 208-215
+	0x87afff, 0xafafff, 0xd7afff, 0xffafff, 0x00d7ff, 0x5fd7ff, 0x87d7ff, 0xafd7ff, // 216-223
+	0xd7d7ff, 0xffd7ff, 0x00ffff, 0x5fffff, 0x87ffff, 0xafffff, 0xd7ffff, 0xffffff, // 224-231
+	0x080808, 0x121212, 0x1c1c1c, 0x262626, 0x303030, 0x3a3a3a, 0x444444, 0x4e4e4e, // 232-239
+	0x585858, 0x626262, 0x6c6c6c, 0x767676, 0x808080, 0x8a8a8a, 0x949494, 0x9e9e9e, // 240-247
+	0xa8a8a8, 0xb2b2b2, 0xbcbcbc, 0xc6c6c6, 0xd0d0d0, 0xdadada, 0xe4e4e4, 0xeeeeee, // 248-255
+};
+
+/*
+* Reset foreground color to default
+*/
+static void psvDebugScreenResetFgColor(void) {
+	colors.fgTrueColorFlag = false;
+	colors.fgTrueColor = 0;
+	colors.fgIndex = colors.fgIndexDefault;
+	colors.fgIntensity = colors.fgIntensityDefault;
+}
+
+/*
+* Reset background color to default
+*/
+static void psvDebugScreenResetBgColor(void) {
+	colors.bgTrueColorFlag = false;
+	colors.bgTrueColor = 0;
+	colors.bgIndex = colors.bgIndexDefault;
+	colors.bgIntensity = colors.bgIntensityDefault;
+}
+
+/*
+* Reset inversion state to default
+*/
+static void psvDebugScreenResetInversion(void) {
+	colors.inversion = colors.inversionDefault;
+}
+
+/*
+* Determine colors according to current color state
+*/
+static void psvDebugScreenSetColors(void) {
+	uint32_t *color_fg, *color_bg;
+
+	// special case: inversion
+	if (!colors.inversion) {
+		color_fg = &colors.color_fg;
+		color_bg = &colors.color_bg;
+	} else {
+		color_fg = &colors.color_bg;
+		color_bg = &colors.color_fg;
+	}
+
+	// foregound color
+	if ((colors.fgIndex<=7) && (colors.fgIntensity==1)) { // ANSI palette with increased intensity
+		colors.fgIndex |= 0x8;
+	} else if ((colors.fgIndex<=15) && (colors.fgIntensity!=1)) { // ANSI palette with standard/decreased intensity
+		colors.fgIndex &= 0x7;
+	}
+	if (colors.fgTrueColorFlag) {
+		*color_fg = colors.fgTrueColor;
+	} else {
+		if ((colors.fgIndex<=7) && (colors.fgIntensity==2)) { // "ANSI" palette with decreased intensity
+			*color_fg = DARK_COLORS_BGR[colors.fgIndex];
+		} else { // ANSI/VTERM/GREYSCALE palette
+			*color_fg = ANSI_COLORS_BGR[colors.fgIndex];
+		}
+	}
+	*color_fg |= 0xFF000000; // opaque
+
+	// backgound color
+	if ((colors.bgIndex<=7) && (colors.bgIntensity==1)) { // ANSI palette with increased intensity
+		colors.bgIndex |= 0x8;
+	} else if ((colors.bgIndex<=15) && (colors.bgIntensity!=1)) { // ANSI palette with standard/decreased intensity
+		colors.bgIndex &= 0x7;
+	}
+	if (colors.bgTrueColorFlag) {
+		*color_bg = colors.bgTrueColor;
+	} else {
+		if ((colors.bgIndex<=7) && (colors.bgIntensity==2)) { // "ANSI" palette with decreased intensity
+			*color_bg = DARK_COLORS_BGR[colors.bgIndex];
+		} else { // ANSI/VTERM/GREYSCALE palette
+			*color_bg = ANSI_COLORS_BGR[colors.bgIndex];
+		}
+	}
+	*color_bg |= 0xFF000000; // opaque
+};
+
+/*
+* Parse CSI sequences
+*/
+static size_t psvDebugScreenEscape(const unsigned char *str) {
+	unsigned int i, argc, arg[32] = { 0 };
+	unsigned int c;
+	uint32_t unit, mode;
+	bool *colorTrueColorFlag;
+	uint32_t *colorTrueColor;
+	unsigned char *colorIndex, *colorIntensity;
+	for (i = 0, argc = 0; (argc < (sizeof(arg)/sizeof(*arg))) && (str[i] != '\0'); i++) {
+		switch (str[i]) {
+			// numeric char
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+				arg[argc] = (arg[argc] * 10) + (str[i] - '0');
+				continue;
+			// argument separator
+			case ';': argc++; continue;
+			// CSI commands
+			// save/restore position
+			case 's':
+				if (arg[0]<SAVE_STORAGES) { savedX[arg[0]] = coordX; savedY[arg[0]] = coordY; }
+				return i;
+			case 'u':
+				if (arg[0]<SAVE_STORAGES) { coordX = savedX[arg[0]]; coordY = savedY[arg[0]]; }
+				return i;
+			// cursor movement
+			case 'A': coordY -= arg[0]    * (F)->size_h; return i;
+			case 'B': coordY += arg[0]    * (F)->size_h; return i;
+			case 'C': coordX += arg[0]    * (F)->size_w; return i;
+			case 'D': coordX -= arg[0]    * (F)->size_w; return i;
+			// cursor movement to beginning of next/previous line(s)
+			case 'E': coordY += arg[0]    * (F)->size_h; coordX = 0; return i;
+			case 'F': coordY -= arg[0]    * (F)->size_h; coordX = 0; return i;
+			// cursor positioning
+			case 'G': coordX = (arg[0]-1) * (F)->size_w; return i;
+			case 'H':
+			case 'f':
+				coordY = (arg[0]-1) * (F)->size_h;
+				coordX = (arg[1]-1) * (F)->size_w;
+				return i;
+			// clear part of "J"=screen or "K"=Line, so J code re-uses part of K
+			case 'J':
+			case 'K':
+				if (arg[0]==0) { // from cursor to end of line/screen
+					CLEARSCRNBLOCK(coordY, coordY + (F)->size_h, coordX, (SCREEN_WIDTH), colors.color_bg); // line
+					if (str[i]=='J') CLEARSCRNLINES(coordY + (F)->size_h, (SCREEN_HEIGHT), colors.color_bg); // screen
+				} else if (arg[0]==1) { // from beginning of line/screen to cursor
+					CLEARSCRNBLOCK(coordY, coordY + (F)->size_h, 0, coordX, colors.color_bg); // line
+					if (str[i]=='J') CLEARSCRNLINES(0, coordY, colors.color_bg); // screen
+				} else if (arg[0]==2) { // whole line/screen
+					if (str[i]=='K') CLEARSCRNLINES(coordY, coordY + (F)->size_h, colors.color_bg) // line
+					else if (str[i]=='J') CLEARSCRNLINES(0, (SCREEN_HEIGHT), colors.color_bg); // screen
+				}
+				return i;
+			// color
+			case 'm':
+				for (c = 0; c <= argc; c++) {
+					switch (arg[c]) {
+						// reset all
+						case 0:
+							psvDebugScreenResetFgColor();
+							psvDebugScreenResetBgColor();
+							psvDebugScreenResetInversion();
+							continue;
+						// intensity
+						case 1: // increased = "bright" color
+						case 2: // decreased = "dark" color
+						case 22: // standard = "normal" color
+							colors.fgIntensity = arg[c];
+							continue;
+						// inversion
+						case 7: // enable
+							colors.inversion = true;
+							continue;
+						case 27: // disable
+							colors.inversion = false;
+							continue;
+						// set from color map or truecolor
+						case 38: // foreground color
+						case 48: // background color
+							mode = arg[c] / 10;
+							colorTrueColorFlag = mode&1 ? &colors.fgTrueColorFlag : &colors.bgTrueColorFlag;
+							if (arg[c+1]==5) { // 8-bit: [0-15][16-231][232-255] color map
+								*colorTrueColorFlag = false;
+								colorIndex = mode&1 ? &colors.fgIndex : &colors.bgIndex;
+								*colorIndex = arg[c+2] & 0xFF;
+								colorIntensity = mode&1 ? &colors.fgIntensity : &colors.bgIntensity;
+								*colorIntensity = ((*colorIndex>=8) && (*colorIndex<=15)) ? 1 : 22;
+								c+=2; // extra arguments
+							} else if (arg[c+1]==2) { // 24-bit color space
+								*colorTrueColorFlag = true;
+								colorTrueColor = mode&1 ? &colors.fgTrueColor : &colors.bgTrueColor;
+								*colorTrueColor = FROM_FULL_RGB(arg[c+2], arg[c+3], arg[c+4]);
+								c+=4; // extra arguments
+							}
+							continue;
+						// default color
+						case 39: // foreground color
+							psvDebugScreenResetFgColor();
+							continue;
+						case 49: // background color
+							psvDebugScreenResetBgColor();
+							continue;
+						// custom color reset
+						default:
+							// ANSI colors (30-37, 40-47, 90-97, 100-107)
+							mode = arg[c] / 10;
+							if ((mode!=3) && (mode!=4) && (mode!=9) && (mode!=10)) continue; // skip unsupported modes
+							unit = arg[c] % 10;
+							if (unit>7) continue; // skip unsupported modes
+							colorTrueColorFlag = mode&1 ? &colors.fgTrueColorFlag : &colors.bgTrueColorFlag;
+							*colorTrueColorFlag = false;
+							colorIndex = mode&1 ? &colors.fgIndex : &colors.bgIndex;
+							*colorIndex = unit;
+							colorIntensity = mode&1 ? &colors.fgIntensity : &colors.bgIntensity;
+							*colorIntensity = mode&8 ? 1 : 22;
+					}
+				}
+				psvDebugScreenSetColors();
+				return i;
+		}
+	}
+	return 0;
+}
+
+/*
+* Initialize debug screen
+*/
+int psvDebugScreenInit() {
+	psvDebugScreenResetFgColor();
+	psvDebugScreenResetBgColor();
+	psvDebugScreenResetInversion();
+	psvDebugScreenSetColors();
+
+#ifdef NO_psvDebugScreenInit
+	psvDebugScreenInitReplacement();
+	return 0; // avoid linking non-initializer (prx) with sceDisplay/sceMemory
+#else
+	mutex = sceKernelCreateMutex("log_mutex", 0, 0, NULL);
+	SceUID displayblock = sceKernelAllocMemBlock("display", SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW, (SCREEN_FB_SIZE), NULL);
+	sceKernelGetMemBlockBase(displayblock, (void**)&base);
+	SceDisplayFrameBuf frame = { sizeof(frame), base, (SCREEN_FB_WIDTH), 0, (SCREEN_WIDTH), (SCREEN_HEIGHT) };
+	return sceDisplaySetFrameBuf(&frame, SCE_DISPLAY_SETBUF_NEXTFRAME);
+#endif
+}
+
+/*
+* Draw text onto debug screen
+*/
+int psvDebugScreenPuts(const char * _text) {
+	const unsigned char*text = (const unsigned char*)_text;
+	int c;
+	unsigned char t;
+	unsigned char drawDummy;
+	//
+	uint32_t *vram;
+	int bits_per_glyph = ((F)->width * (F)->height);
+	int bitmap_offset;
+	unsigned char *font;
+	int row;
+	int max_row;
+	int col;
+	unsigned char mask;
+	uint32_t *pixel;
+
+	sceKernelLockMutex(mutex, 1, NULL);
+	for (c = 0; text[c] ; c++) {
+		t = text[c];
+		// handle CSI sequence
+		if ((t == '\e') && (text[c+1] == '[')) {
+			c += psvDebugScreenEscape(text + c + 2) + 2;
+			if (coordX < 0) coordX = 0; // CSI position are 1-based,
+			if (coordY < 0) coordY = 0; // prevent 0-based coordinate from producing a negative X/Y
+			continue;
+		}
+		// handle non-printable characters #1 (line-dependent codes)
+		if (t == '\n') {
+			coordX = 0;
+			coordY += (F)->size_h;
+			continue;
+		}
+		if (t == '\r') {
+			coordX = 0;
+			continue;
+		}
+		// check if glyph fits in line
+		if ((coordX + (F)->width) > (SCREEN_WIDTH)) {
+			coordY += (F)->size_h;
+			coordX = 0;
+		}
+		// check if glyph fits in screen
+		if ((coordY + (F)->height) > (SCREEN_HEIGHT)) {
+			coordX = coordY = 0;
+		}
+		// handle non-printable characters #2
+		if (t == '\t') {
+			coordX += (SCREEN_TAB_W) - (coordX % (SCREEN_TAB_W));
+			continue;
+		}
+
+		// draw glyph or dummy glyph (dotted line in the middle)
+		// works also with not byte-aligned glyphs
+		vram = ((uint32_t*)base) + coordX + (coordY * (SCREEN_FB_WIDTH));
+		row = 0;
+		// check if glyph is available in font
+		if ((t > (F)->last) || (t < (F)->first)) {
+			drawDummy = true;
+		} else {
+			drawDummy = false;
+			bitmap_offset = (t - (F)->first) * bits_per_glyph;
+			font = &(F)->glyphs[ (bitmap_offset / 8) ];
+			mask = 1 << 7;
+			for (col = (bitmap_offset % 8); col > 0; col--, mask >>= 1);
+		}
+		// special case: dummy glyph, clear to middle height
+		max_row = 0;
+		if (drawDummy) {
+			max_row = (F)->height / 2;
+			for (; row < max_row; row++, vram += (SCREEN_FB_WIDTH)) {
+				pixel = vram;
+				col = 0;
+				for (; col < (F)->size_w ; col++) {
+					*pixel++ = colors.color_bg;
+				}
+			}
+		}
+		// draw font glyph or dummy glyph
+		if (drawDummy) {
+			max_row++;
+			if (max_row > (F)->height) max_row = (F)->height;
+		} else {
+			max_row = (F)->height;
+		}
+		for (; row < max_row; row++, vram += (SCREEN_FB_WIDTH)) {
+			pixel = vram;
+			col = 0;
+			for (; col < (F)->width ; col++, mask >>= 1) {
+				if (drawDummy) {
+					*pixel++ = (col&1) ? colors.color_fg : colors.color_bg;
+				} else {
+					if (!mask) { font++; mask = 1 << 7; } // no more bits: we exhausted this byte
+					*pixel++ = (*font&mask) ? colors.color_fg : colors.color_bg;
+				}
+			}
+			// right margin
+			for (; col < (F)->size_w ; col++)
+				*pixel++ = colors.color_bg;
+		}
+		// draw bottom margin
+		max_row = (F)->size_h;
+		for (; row < (F)->size_h; row++, vram += (SCREEN_FB_WIDTH))
+			for (pixel = vram, col = 0; col < (F)->size_w ; col++)
+				*pixel++ = colors.color_bg;
+		// advance X position
+		coordX += (F)->size_w;
+	}
+	sceKernelUnlockMutex(mutex, 1);
+	return c;
+}
+
+
+/*
+* Printf text onto debug screen
+*/
+__attribute__((__format__ (__printf__, 1, 2)))
+int psvDebugScreenPrintf(const char *format, ...) {
+	char buf[4096];
+
+	va_list opt;
+	va_start(opt, format);
+	int ret = vsnprintf(buf, sizeof(buf), format, opt);
+	psvDebugScreenPuts(buf);
+	va_end(opt);
+
+	return ret;
+}
+
+/*
+* Return copy of color state
+*/
+void psvDebugScreenGetColorStateCopy(ColorState *copy) {
+	if (copy) {
+		memcpy(copy, &colors, sizeof(ColorState));
+		CONVERT_RGB_BGR(copy->fgTrueColor);
+		CONVERT_RGB_BGR(copy->bgTrueColor);
+		CONVERT_RGB_BGR(copy->color_fg);
+		CONVERT_RGB_BGR(copy->color_bg);
+	}
+}
+
+/*
+* Return copy of pixel coordinates
+*/
+void psvDebugScreenGetCoordsXY(int *x, int *y) {
+	if (x) *x = coordX;
+	if (y) *y = coordY;
+}
+
+/*
+* Set pixel coordinates
+*/
+void psvDebugScreenSetCoordsXY(int *x, int *y) {
+	if (x) {
+		coordX = *x;
+		if (coordX < 0) coordX = 0;
+	}
+	if (y) {
+		coordY = *y;
+		if (coordY < 0) coordY = 0;
+	}
+}
+
+/*
+* Return pointer to current font
+*/
+PsvDebugScreenFont *psvDebugScreenGetFont(void) {
+	return F;
+}
+
+/*
+* Set font
+*/
+PsvDebugScreenFont *psvDebugScreenSetFont(PsvDebugScreenFont *font) {
+	if ((font) && (font->glyphs)) F = font;
+	return F;
+}
+
+/*
+* Return scaled-by-2 copy of font
+*/
+PsvDebugScreenFont *psvDebugScreenScaleFont2x(PsvDebugScreenFont *source_font) {
+	// works also with not byte-aligned glyphs
+	PsvDebugScreenFont *target_font;
+	size_t size;
+	size_t align;
+	int glyph;
+	int row;
+	int col;
+	int count;
+	unsigned char *source_bitmap;
+	unsigned char source_mask;
+	unsigned char *target_bitmap, *target_bitmap2;
+	unsigned char target_mask, target_mask2;
+	int target_next_row_bytes, target_next_row_bits;
+	unsigned char pixel;
+
+	if (!source_font) return NULL;
+
+	// allocate target structure and bitmap
+	target_font = (PsvDebugScreenFont *)malloc(sizeof(PsvDebugScreenFont));
+	memset(target_font, 0, sizeof(PsvDebugScreenFont));
+	// copy and scale meta information
+	target_font->width = 2 * source_font->width;
+	target_font->height = 2 * source_font->height;
+	target_font->first = source_font->first;
+	target_font->last = source_font->last;
+	target_font->size_w = 2 * source_font->size_w;
+	target_font->size_h = 2 * source_font->size_h;
+
+	// calculate size of target bitmap
+	size = target_font->width * target_font->height * (target_font->last - target_font->first + 1);
+	if (size <= 0) {
+		free(target_font);
+		return NULL;
+	}
+	align = size % 8;
+	size /= 8;
+	if (align) size++;
+
+	// allocate and initialize target bitmap
+	target_font->glyphs = (unsigned char *)malloc(size);
+	memset(target_font->glyphs, 0, size);
+
+	// scale source bitmap and store in target bitmap
+	source_bitmap = source_font->glyphs;
+	source_mask = 1 << 7;
+	//
+	target_bitmap = target_font->glyphs;
+	target_mask = 1 << 7;
+	target_next_row_bytes = target_font->width / 8;
+	target_next_row_bits = target_font->width % 8;
+	//
+	for (glyph = source_font->first; glyph <= source_font->last; glyph++) {
+		for (row = source_font->height; row > 0; row--) {
+			// Find beginning of next target row
+			target_bitmap2 = target_bitmap + target_next_row_bytes; // advance full bytes
+			target_mask2 = target_mask; // advance remaining bits
+			for (col = target_next_row_bits; col > 0; col--, target_mask2 >>= 1) {
+				if (!target_mask2) { target_bitmap2++; target_mask2 = 1 << 7; } // no more bits: we advance to the next target byte
+			}
+			// Get pixel from source bitmap
+			for (col = source_font->width; col > 0; col--, source_mask >>= 1) {
+				if (!source_mask) { source_bitmap++; source_mask = 1 << 7; } // no more bits: we advance to the next source byte
+				pixel = *source_bitmap & source_mask;
+				// Put pixels into target bitmap
+				for (count = 2; count > 0; count--) {
+					// duplicate column in origial row
+					if (!target_mask) { target_bitmap++; target_mask = 1 << 7; } // no more bits: we advance to the next target byte
+					if (pixel) *target_bitmap |= target_mask;
+					target_mask >>= 1;
+					// duplicate column in duplicated row
+					if (!target_mask2) { target_bitmap2++; target_mask2 = 1 << 7; } // no more bits: we advance to the next target byte
+					if (pixel) *target_bitmap2 |= target_mask2;
+					target_mask2 >>= 1;
+				}
+			}
+			// Next target row is directly behind duplicated row
+			target_bitmap = target_bitmap2;
+			target_mask = target_mask2;
+		}
+	}
+
+	return target_font;
+}
+
+#undef SCREEN_TAB_W
+#undef F
+
+#endif

--- a/common/debugScreen.c
+++ b/common/debugScreen.c
@@ -118,11 +118,12 @@
 
 static int mutex, coordX, coordY;
 static int savedX[SAVE_STORAGES] = { 0 }, savedY[SAVE_STORAGES] = { 0 };
-static ColorState colors = { 0, 0, // truecolor flags
-                             0, 0, // truecolors
-                             0, 0, 0, 0, 0, // ANSI/VTERM/GREYSCALE colors
-                             7, 22, 0, 22, 0, // default colors (ANSI/VTERM/GREYSCALE)
-                           };
+static ColorState colors = {
+	0, 0, // truecolor flags
+	0, 0, // truecolors
+	0, 0, 0, 0, 0, // ANSI/VTERM/GREYSCALE colors
+	7, 22, 0, 22, 0, // default colors (ANSI/VTERM/GREYSCALE)
+};
 
 static PsvDebugScreenFont *psvDebugScreenFontCurrent = &psvDebugScreenFont;
 
@@ -258,7 +259,7 @@ static void psvDebugScreenSetColors(void) {
 		}
 	}
 	*color_bg |= 0xFF000000; // opaque
-};
+}
 
 /*
 * Parse CSI sequences
@@ -334,19 +335,23 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 							psvDebugScreenResetBgColor();
 							psvDebugScreenResetInversion();
 							continue;
+							break;
 						// intensity
 						case 1: // increased = "bright" color
 						case 2: // decreased = "dark" color
 						case 22: // standard = "normal" color
 							colors.fgIntensity = arg[c];
 							continue;
+							break;
 						// inversion
 						case 7: // enable
 							colors.inversion = 1;
 							continue;
+							break;
 						case 27: // disable
 							colors.inversion = 0;
 							continue;
+							break;
 						// set from color map or truecolor
 						case 38: // foreground color
 						case 48: // background color
@@ -366,13 +371,16 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 								c+=4; // extra arguments
 							}
 							continue;
+							break;
 						// default color
 						case 39: // foreground color
 							psvDebugScreenResetFgColor();
 							continue;
+							break;
 						case 49: // background color
 							psvDebugScreenResetBgColor();
 							continue;
+							break;
 						// custom color reset
 						default:
 							// ANSI colors (30-37, 40-47, 90-97, 100-107)
@@ -386,6 +394,7 @@ static size_t psvDebugScreenEscape(const unsigned char *str) {
 							*colorIndex = unit;
 							colorIntensity = mode&1 ? &colors.fgIntensity : &colors.bgIntensity;
 							*colorIntensity = mode&8 ? 1 : 22;
+							break;
 					}
 				}
 				psvDebugScreenSetColors();

--- a/common/debugScreen.h
+++ b/common/debugScreen.h
@@ -37,18 +37,24 @@ typedef struct PsvDebugScreenFont {
 #define SCREEN_WIDTH    (960) // screen resolution x
 #define SCREEN_HEIGHT   (544) // screen resolution y
 
-#ifdef DEBUG_SCREEN_CODE_INCLUDE // needed once inside a C++ project (e.g. main.cpp)
+#ifdef DEBUG_SCREEN_CODE_INCLUDE // not recommended for your own projects, but for sake of backward compatibility
 #include "debugScreen.c"
 #else
-extern int psvDebugScreenInit();
-extern int psvDebugScreenPuts(const char * _text);
-extern int psvDebugScreenPrintf(const char *format, ...);
-extern void psvDebugScreenGetColorStateCopy(ColorState *copy);
-extern void psvDebugScreenGetCoordsXY(int *x, int *y);
-extern void psvDebugScreenSetCoordsXY(int *x, int *y);
-extern PsvDebugScreenFont *psvDebugScreenGetFont(void);
-extern PsvDebugScreenFont *psvDebugScreenSetFont(PsvDebugScreenFont *font);
-extern PsvDebugScreenFont *psvDebugScreenScaleFont2x(PsvDebugScreenFont *source_font);
+#ifdef __cplusplus
+extern "C" {
+#endif
+int psvDebugScreenInit();
+int psvDebugScreenPuts(const char * _text);
+int psvDebugScreenPrintf(const char *format, ...);
+void psvDebugScreenGetColorStateCopy(ColorState *copy);
+void psvDebugScreenGetCoordsXY(int *x, int *y);
+void psvDebugScreenSetCoordsXY(int *x, int *y);
+PsvDebugScreenFont *psvDebugScreenGetFont(void);
+PsvDebugScreenFont *psvDebugScreenSetFont(PsvDebugScreenFont *font);
+PsvDebugScreenFont *psvDebugScreenScaleFont2x(PsvDebugScreenFont *source_font);
+#ifdef __cplusplus
+}
+#endif
 #endif
 
-#endif
+#endif /* DEBUG_SCREEN_H */

--- a/common/debugScreen.h
+++ b/common/debugScreen.h
@@ -1,13 +1,11 @@
 #ifndef DEBUG_SCREEN_H
 #define DEBUG_SCREEN_H
 
-#include <stdbool.h> // for bool
-
 #include "debugScreen_custom.h"
 
 typedef struct ColorState {
-	bool fgTrueColorFlag; // flag if truecolors or ANSI/VTERM/GREYSCALE colors are used
-	bool bgTrueColorFlag; // flag if truecolors or ANSI/VTERM/GREYSCALE colors are used
+	int fgTrueColorFlag; // flag if truecolors or ANSI/VTERM/GREYSCALE colors are used
+	int bgTrueColorFlag; // flag if truecolors or ANSI/VTERM/GREYSCALE colors are used
 	// truecolors
 	uint32_t fgTrueColor; // color in RGB (internal BGR)
 	uint32_t bgTrueColor; // color in RGB (internal BGR)
@@ -16,14 +14,14 @@ typedef struct ColorState {
 	unsigned char fgIntensity; // 22=normal, 1=increased ("bright"), 2=decreased ("dark")
 	unsigned char bgIndex; // ANSI/VTERM/GREYSCALE color code (0-255)
 	unsigned char bgIntensity; // 22=normal, 1=increased ("bright")
-	bool inversion; // flag if bg/fg colors are inverted
+	int inversion; // flag if bg/fg colors are inverted
 
 	// default colors (ANSI/VTERM/GREYSCALE)
 	unsigned char fgIndexDefault; // default ANSI/VTERM/GREYSCALE color code
 	unsigned char fgIntensityDefault; // 22=normal, 1=increased, 2=decreased
 	unsigned char bgIndexDefault; // default ANSI/VTERM/GREYSCALE color code
 	unsigned char bgIntensityDefault; // 22=normal, 1=increased
-	bool inversionDefault; // flag if bg/fg colors are inverted
+	int inversionDefault; // flag if bg/fg colors are inverted
 
 	// current colors (e.g. inverted)
 	uint32_t color_fg; // color in RGB (internal BGR)

--- a/common/debugScreen.h
+++ b/common/debugScreen.h
@@ -1,176 +1,54 @@
 #ifndef DEBUG_SCREEN_H
 #define DEBUG_SCREEN_H
 
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
-#include <inttypes.h>
+#include <stdbool.h> // for bool
+
+#include "debugScreen_custom.h"
+
+typedef struct ColorState {
+	bool fgTrueColorFlag; // flag if truecolors or ANSI/VTERM/GREYSCALE colors are used
+	bool bgTrueColorFlag; // flag if truecolors or ANSI/VTERM/GREYSCALE colors are used
+	// truecolors
+	uint32_t fgTrueColor; // color in RGB (internal BGR)
+	uint32_t bgTrueColor; // color in RGB (internal BGR)
+	// ANSI/VTERM/GREYSCALE colors
+	unsigned char fgIndex; // ANSI/VTERM/GREYSCALE color code (0-255)
+	unsigned char fgIntensity; // 22=normal, 1=increased ("bright"), 2=decreased ("dark")
+	unsigned char bgIndex; // ANSI/VTERM/GREYSCALE color code (0-255)
+	unsigned char bgIntensity; // 22=normal, 1=increased ("bright")
+	bool inversion; // flag if bg/fg colors are inverted
+
+	// default colors (ANSI/VTERM/GREYSCALE)
+	unsigned char fgIndexDefault; // default ANSI/VTERM/GREYSCALE color code
+	unsigned char fgIntensityDefault; // 22=normal, 1=increased, 2=decreased
+	unsigned char bgIndexDefault; // default ANSI/VTERM/GREYSCALE color code
+	unsigned char bgIntensityDefault; // 22=normal, 1=increased
+	bool inversionDefault; // flag if bg/fg colors are inverted
+
+	// current colors (e.g. inverted)
+	uint32_t color_fg; // color in RGB (internal BGR)
+	uint32_t color_bg; // color in RGB (internal BGR)
+} ColorState;
 
 typedef struct PsvDebugScreenFont {
-	unsigned char* glyphs, width, height, first, last, size_w, size_h;
+	unsigned char *glyphs, width, height, first, last, size_w, size_h; // only values 0-255
 } PsvDebugScreenFont;
 
-#include <debugScreenFont.c>
+#define SCREEN_WIDTH    (960) // screen resolution x
+#define SCREEN_HEIGHT   (544) // screen resolution y
 
-#define SCREEN_WIDTH    (960)
-#define SCREEN_HEIGHT   (544)
-#define SCREEN_FB_WIDTH (960)
-#define SCREEN_FB_SIZE  (2 * 1024 * 1024) //Must be 256KB aligned
-#ifndef SCREEN_TAB_SIZE /* this allow easy overriding */
-#define SCREEN_TAB_SIZE (8)
-#endif
-#define SCREEN_TAB_W    ((F.size_w) * SCREEN_TAB_SIZE)
-#define F psvDebugScreenFont
-
-#define FROM_GREY(c     ) ((((c)*9)    <<16)  |  (((c)*9)       <<8)  | ((c)*9))
-#define FROM_3BIT(c,dark) (((!!((c)&4))<<23)  | ((!!((c)&2))<<15)     | ((!!((c)&1))<<7) | (dark ? 0 : 0x7F7F7F))
-#define FROM_6BIT(c     ) ((((c)%6)*(51<<16)) | ((((c)/6)%6)*(51<<8)) | ((((c)/36)%6)*51))
-#define FROM_FULL(r,g,b ) ((r<<16) | (g<<8) | (b))
-#define CLEARSCRN(H,toH,W,toW) for(int h = H; h < toH; h++)for(int w = W; w < toW; w++)((uint32_t*)base)[h*SCREEN_FB_WIDTH + w] = colorBg;
-
-static int mutex, coordX, savedX, coordY, savedY;
-static uint32_t defaultFg = 0xFFFFFFFF, colorFg = 0xFFFFFFFF;
-static uint32_t defaultBg = 0xFF000000, colorBg = 0xFF000000;
-
-
-#ifdef __vita__
-#include <psp2/display.h>
-#include <psp2/kernel/sysmem.h>
-#include <psp2/kernel/threadmgr.h>
-static void* base; // pointer to frame buffer
+#ifdef DEBUG_SCREEN_CODE_INCLUDE // needed once inside a C++ project (e.g. main.cpp)
+#include "debugScreen.c"
 #else
-#define sceKernelLockMutex(m,v,x) m=v
-#define sceKernelUnlockMutex(m,v) m=v
-static char base[SCREEN_FB_WIDTH * SCREEN_HEIGHT * 4];
+extern int psvDebugScreenInit();
+extern int psvDebugScreenPuts(const char * _text);
+extern int psvDebugScreenPrintf(const char *format, ...);
+extern void psvDebugScreenGetColorStateCopy(ColorState *copy);
+extern void psvDebugScreenGetCoordsXY(int *x, int *y);
+extern void psvDebugScreenSetCoordsXY(int *x, int *y);
+extern PsvDebugScreenFont *psvDebugScreenGetFont(void);
+extern PsvDebugScreenFont *psvDebugScreenSetFont(PsvDebugScreenFont *font);
+extern PsvDebugScreenFont *psvDebugScreenScaleFont2x(PsvDebugScreenFont *source_font);
 #endif
 
-static size_t psvDebugScreenEscape(const unsigned char *str) {
-	for(unsigned i = 0, argc = 0, arg[32] = {0}; argc < (sizeof(arg)/sizeof(*arg)) && str[i]!='\0'; i++)
-		switch(str[i]) {
-		case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
-			arg[argc]=(arg[argc]*10) + (str[i] - '0');continue;
-		case ';': argc++;continue;
-		case 's': savedX = coordX; savedY = coordY; return i;
-		case 'u': coordX = savedX; coordY = savedY; return i;
-		case 'A': coordY -= arg[0]    * (F.size_h); return i;
-		case 'B': coordY += arg[0]    * (F.size_h); return i;
-		case 'C': coordX += arg[0]    * (F.size_w); return i;
-		case 'D': coordX -= arg[0]    * (F.size_w); return i;
-		case 'E': coordY += arg[0]    * (F.size_h); coordX = 0; return i;
-		case 'F': coordY -= arg[0]    * (F.size_h); coordX = 0; return i;
-		case 'G': coordX = (arg[0]-1) * (F.size_w); return i;
-		case 'H': 
-		case 'f': coordY = (arg[0]-1) * (F.size_h);
-		          coordX = (arg[1]-1) * (F.size_w); return i;
-		case 'J': //clear part of (J=screen, K=Line) so J code reuse part of K
-		case 'K': if(arg[0]==0)CLEARSCRN(coordY, coordY + F.size_h, coordX, SCREEN_WIDTH);//from curosr to end
-		          if(arg[0]==1)CLEARSCRN(coordY, coordY + F.size_h, 0, coordX);//from begining to cursor
-		          if(arg[0]==2)CLEARSCRN(coordY, coordY + F.size_h, 0, SCREEN_WIDTH);//whole line
-		          if(str[i]=='K')return i;
-		          if(arg[0]==0)CLEARSCRN(coordY, SCREEN_HEIGHT, 0, SCREEN_WIDTH);
-		          if(arg[0]==1)CLEARSCRN(0, coordY, 0, SCREEN_WIDTH);
-		          if(arg[0]==2)CLEARSCRN(0, SCREEN_HEIGHT, 0, SCREEN_WIDTH);
-		          return i;
-		case 'm':// Color
-			if(!arg[0]) {arg[0] = 39;arg[1] = 49;argc = 1;}//no/0 args == reset BG + FG
-			for(unsigned c = 0; c <= argc; c++) {
-				uint32_t unit = arg[c] % 10, mode = arg[c] / 10, *color = mode&1 ? &colorFg : &colorBg;
-				if (arg[c]==1)colorFg|=0x808080;
-				if (arg[c]==2)colorFg&=0x7F7F7F;
-				if (mode!=3 && mode!=4 && mode!=9 && mode!=10)continue;//skip unsported modes
-				if (unit == 9){ // reset FG or BG
-					*color = mode&1 ? defaultFg : defaultBg;
-				} else if ((unit==8) && (arg[c+1]==5)) { // 8bit : [0-15][16-231][232-256] color map
-					c+=2;*color = arg[c]<=15?FROM_3BIT(arg[c],mode<9):arg[c]>=232?FROM_GREY(arg[c]-232):FROM_6BIT(arg[c]-16);
-				} else if ((unit==8) && (arg[c+1]==2)) { // 24b color space
-					*color = FROM_FULL(arg[c+4], arg[c+3], arg[c+2]);c+=4;
-				} else *color = FROM_3BIT(unit,mode<9); // standard 8+8 colors
-			}
-			return i;
-		}
-	return 0;
-}
-int psvDebugScreenInit() {
-#ifdef NO_psvDebugScreenInit
-	return 0;/* avoid linking non-initializer (prx) with sceDisplay/sceMemory */
-#else
-	mutex = sceKernelCreateMutex("log_mutex", 0, 0, NULL);
-	SceUID displayblock = sceKernelAllocMemBlock("display", SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW, SCREEN_FB_SIZE, NULL);
-	sceKernelGetMemBlockBase(displayblock, (void**)&base);
-	SceDisplayFrameBuf frame = { sizeof(frame), base, SCREEN_FB_WIDTH, 0, SCREEN_WIDTH, SCREEN_HEIGHT};
-	return sceDisplaySetFrameBuf(&frame, SCE_DISPLAY_SETBUF_NEXTFRAME);
-#endif
-}
-
-int psvDebugScreenPuts(const char * _text) {
-	const unsigned char*text = (const unsigned char*)_text;
-	int bytes_per_glyph = (F.width * F.height) / 8;
-	sceKernelLockMutex(mutex, 1, NULL);
-	int c;
-	for (c = 0; text[c] ; c++) {
-		unsigned char t = text[c];
-		if (t == '\t') {
-			coordX += SCREEN_TAB_W - coordX % SCREEN_TAB_W;
-			continue;
-		}
-		if (coordX + F.width > SCREEN_WIDTH) {
-			coordY += F.size_h;
-			coordX = 0;
-		}
-		if (coordY + F.height > SCREEN_HEIGHT) {
-			coordX = coordY = 0;
-		}
-		if (t == '\n') {
-			coordX = 0;
-			coordY += F.size_h;
-			continue;
-		} else if (t == '\r') {
-			coordX = 0;
-			continue;
-		} else if ((t == '\e') && (text[c+1] == '[')) {
-			c += psvDebugScreenEscape(text + c + 2) + 2;
-			if(coordX < 0)coordX = 0;// CSI position are 1-based, 
-			if(coordY < 0)coordY = 0;// prevent 0-based coordiate from producing a negativ X/Y
-			continue;
-		}else if ((t > F.last) || (t < F.first))
-			continue; // skip non printable glyph
-		uint32_t *vram = ((uint32_t*)base) + coordX + coordY * SCREEN_FB_WIDTH;
-		uint8_t *font = &F.glyphs[ (t - F.first) * bytes_per_glyph];
-		for (int row = 0, mask = 1 << 7; row < F.height; row++, vram += SCREEN_FB_WIDTH) {
-			for (uint32_t *pixel = vram, col = 0; col < F.width ; col++, mask>>=1) {
-				if (!mask) {font++; mask = 1 << 7;}// no more mask : we exausted this byte
-				*pixel++ = (*font&mask)?colorFg:colorBg;
-			}
-			for (uint32_t *pixel = vram + F.width, col = F.width; col < F.size_w ; col++)
-				*pixel++ = colorBg;// right margin
-		}
-		for (int row = F.height; row < F.size_h; row++, vram += SCREEN_FB_WIDTH)
-			for (uint32_t *pixel = vram, col = 0; col < F.size_w ; col++)
-				*pixel++ = colorBg;// bottom margin
-		coordX += F.size_w;
-	}
-	sceKernelUnlockMutex(mutex, 1);
-	return c;
-}
-
-__attribute__((__format__ (__printf__, 1, 2)))
-int psvDebugScreenPrintf(const char *format, ...) {
-	char buf[4096];
-
-	va_list opt;
-	va_start(opt, format);
-	int ret = vsnprintf(buf, sizeof(buf), format, opt);
-	psvDebugScreenPuts(buf);
-	va_end(opt);
-
-	return ret;
-}
-
-void psvDebugScreenSetFgColor(uint32_t rgb){
-	psvDebugScreenPrintf("\e[38;2;%lu;%lu;%lum", (rgb>>16)&0xFF, (rgb>>8)&0xFF, rgb&0xFF);
-}
-void psvDebugScreenSetBgColor(uint32_t rgb){
-	psvDebugScreenPrintf("\e[48;2;%lu;%lu;%lum", (rgb>>16)&0xFF, (rgb>>8)&0xFF, rgb&0xFF);
-}
-#undef F
 #endif

--- a/common/debugScreenFont.builder.html
+++ b/common/debugScreenFont.builder.html
@@ -12,15 +12,21 @@
 function toHTML(c_source) {
 	var f=eval(source.value.replace(/(\/\*[\s\S]*?\*\/|"\s"|PsvDebugScreenFont|\(.*?\))/g,''))
 	if((f.width * f.height) % 8)
-		return alert("Font Width*Height not a byte(8) multiple");
+		alert("Font Width*Height not a byte(8) multiple");
 	var w = f.width, h = f.height;
 	var bits = [].concat(...f.glyphs.split('').map(c=>('0000000'+c.charCodeAt(0).toString(2)).slice(-8).split('').map(c=>+c)));
+	var glyphs_in_bits = Math.floor((f.glyphs.length*8) / (w*h))
+	var align = (f.glyphs.length*8) % (w*h)
+	for (; align > 0; align--) bits.pop();
 	var style = 'style="grid-template-columns:'+[...Array(w)].map(c=>"auto").join(' ')+'"';
-	return [...Array((f.glyphs.length*8)/(w*h))].map((c,i)=>'<div class="glyph" oncontextmenu="[...this.children].forEach(i=>i.removeAttribute(\'checked\'));event.preventDefault()" '+style+' title="&#'+(i + f.first)+'; ('+(i + f.first)+')">'+
+	return [...Array(glyphs_in_bits)].map((c,i)=>'<div class="glyph" oncontextmenu="[...this.children].forEach(i=>i.removeAttribute(\'checked\'));event.preventDefault()" '+style+' title="&#'+(i + f.first)+'; ('+(i + f.first)+')">'+
 	       [...Array(w*h)].map((c,j)=>'<input type="checkbox" '+(bits[i*w*h+j]?'checked':'')+'/>').join('')+'</div>').join('')
 }
 function toHeader(checks) {
-	var glyphs = checks.map(i=>i.checked?'1':'0').join('').match(/.{8}/g).map(s=>'\\x'+("0"+parseInt(s,2).toString(16)).slice(-2)).join('');
+	var glyphs_bits = checks.map(i=>i.checked?'1':'0').join('');
+	var align = glyphs_bits.length % 8
+	if (align > 0) glyphs_bits += "0".repeat(8 - align);
+	var glyphs = glyphs_bits.match(/.{8}/g).map(s=>'\\x'+("0"+parseInt(s,2).toString(16).toUpperCase()).slice(-2)).join('');
 	return `PsvDebugScreenFont psvDebugScreenFont = {
 	glyphs:(unsigned char*)"${glyphs}",
 	width :${psvDebugScreenFont.width},

--- a/common/debugScreen_custom.h
+++ b/common/debugScreen_custom.h
@@ -4,7 +4,7 @@
 //#define SCREEN_TAB_SIZE (8)
 
 // backward compatibility for sources based on older Vita SDK versions
-#define DEBUG_SCREEN_CODE_INCLUDE // not recommended for your own projects, but for sake of backward compatibility
+//#define DEBUG_SCREEN_CODE_INCLUDE // not recommended for your own projects, but for sake of backward compatibility
 #define psvDebugScreenSetFgColor(rgb) psvDebugScreenPrintf("\e[38;2;%lu;%lu;%lum", ((uint32_t)(rgb)>>16)&0xFF, ((uint32_t)(rgb)>>8)&0xFF, (uint32_t)(rgb)&0xFF)
 #define psvDebugScreenSetBgColor(rgb) psvDebugScreenPrintf("\e[48;2;%lu;%lu;%lum", ((uint32_t)(rgb)>>16)&0xFF, ((uint32_t)(rgb)>>8)&0xFF, (uint32_t)(rgb)&0xFF)
 #define psvDebugScreenClear(rgb) psvDebugScreenSetBgColor(rgb); psvDebugScreenPuts("\e[H\e[2J")

--- a/common/debugScreen_custom.h
+++ b/common/debugScreen_custom.h
@@ -1,0 +1,17 @@
+#ifndef DEBUG_SCREEN_CUSTOM_H
+#define DEBUG_SCREEN_CUSTOM_H
+
+//#define SCREEN_TAB_SIZE (8)
+
+// backward compatibility for sources based on older Vita SDK versions
+#define DEBUG_SCREEN_CODE_INCLUDE // not recommended for your own projects, but for sake of backward compatibility
+#define psvDebugScreenSetFgColor(rgb) psvDebugScreenPrintf("\e[38;2;%lu;%lu;%lum", ((uint32_t)(rgb)>>16)&0xFF, ((uint32_t)(rgb)>>8)&0xFF, (uint32_t)(rgb)&0xFF)
+#define psvDebugScreenSetBgColor(rgb) psvDebugScreenPrintf("\e[48;2;%lu;%lu;%lum", ((uint32_t)(rgb)>>16)&0xFF, ((uint32_t)(rgb)>>8)&0xFF, (uint32_t)(rgb)&0xFF)
+#define psvDebugScreenClear(rgb) psvDebugScreenSetBgColor(rgb); psvDebugScreenPuts("\e[H\e[2J")
+
+// custom changes for non-Vita builds
+#ifndef __vita__
+#define psvDebugScreenInitReplacement(...) setvbuf(stdout,NULL,_IONBF,0)
+#endif
+
+#endif

--- a/ctrl/CMakeLists.txt
+++ b/ctrl/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/debug_print/CMakeLists.txt
+++ b/debug_print/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/debugscreen/CMakeLists.txt
+++ b/debugscreen/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/hello_world/CMakeLists.txt
+++ b/hello_world/CMakeLists.txt
@@ -51,6 +51,7 @@ link_directories(
 # Add all the files needed to compile here
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 # Library to link to (drop the -l prefix). This will mostly be stubs.

--- a/microphone/CMakeLists.txt
+++ b/microphone/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/microphone/src/main.c
+++ b/microphone/src/main.c
@@ -18,6 +18,7 @@
 #include <psp2/ctrl.h>
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "debugScreen.h"
 
@@ -41,7 +42,7 @@ int main(int argc, char *argv[]){
 	int port = 0;
 
 	/* If size > grain */
-	/* audio buffer will be filled only up to [grain - 1] */ 
+	/* audio buffer will be filled only up to [grain - 1] */
 	int size = 256;
 	short *audioIn = NULL;
 
@@ -56,10 +57,10 @@ int main(int argc, char *argv[]){
 				SCE_AUDIO_IN_PARAM_FORMAT_S16_MONO);
 
 	printf("Port value 0x%X - buff size %d\n", port, size);
-	
+
 	/* Check for SceAudioInErrorCode enums */
 	if (0 > port){
-		exit = 1;		
+		exit = 1;
 	}
 
 	printf("Audio buff address = 0x%X\n\n", audioIn);
@@ -71,15 +72,14 @@ int main(int argc, char *argv[]){
 	int audioInMax;
 	int sensitivity = 3;
 	int retVal;
-	int originY = coordY;
 
 	SceCtrlData ctrl, oldCtrl;
 
+	printf("\e[s");  // save cursor position
 	while (!exit){
 		average = 0;
 		audioInMax = 0;
-		coordY = originY;
-		coordX = 0;
+		printf("\e[u");  // return to saved cursor position
 		/* Read audio */
 		retVal = sceAudioInInput(port, (void*)audioIn);
 		if (retVal){
@@ -99,18 +99,18 @@ int main(int argc, char *argv[]){
 
 				if (audioInMax < audioIn[i + j])
 					audioInMax = audioIn[i + j];
-			}		
+			}
 			printf("\n");
 		}
-		
+
 		average /= size;
-		average = ((average * sensitivity) * MAX_VU) / audioInMax;	
+		average = ((average * sensitivity) * MAX_VU) / audioInMax;
 		/* Get microphone status */
 		/* Other values than 1 in GetStatus returns 0x80260106 */
 		printf("\nYour microphone is %s\n\n", sceAudioInGetStatus(1)?"disabled.": "enabled. ");
-		printf("\nSimple VU meter: (sensitivity = %3d)\n\n\n", sensitivity);		
+		printf("\nSimple VU meter: (sensitivity = %3d)\n\n\n", sensitivity);
 		for (i = 0; i < MAX_VU; i++){
-			coordX = 56;
+			printf("\e[7G");  // set cursor to column 7 (for 8x8 font)
 			if (i < average){
 				if (MAX_VU/2 > i)
 					psvDebugScreenSetBgColor(0xFF00FF00);
@@ -140,7 +140,7 @@ int main(int argc, char *argv[]){
 
 		memcpy(&oldCtrl, &ctrl, sizeof(SceCtrlData));
 
-		sceKernelDelayThread(10000);		
+		sceKernelDelayThread(10000);
 	}
 
 	free(audioIn);

--- a/motion/CMakeLists.txt
+++ b/motion/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/net_http/CMakeLists.txt
+++ b/net_http/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/net_http_bsd/CMakeLists.txt
+++ b/net_http_bsd/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/net_http_bsd/src/main.c
+++ b/net_http_bsd/src/main.c
@@ -72,9 +72,11 @@ int main (__attribute__((unused)) int argc,  __attribute__((unused)) char *argv[
 	char* wttr[] = {"wttr.in","/London"};
 	char* rate[] = {"rate.sx","/"};
 	char**url = NULL;// will point to wttr or rate
+	PsvDebugScreenFont *psvDebugScreenFont_current;
 
 	psvDebugScreenInit();
-	psvDebugScreenFont.size_w-=1;//narrow character printing
+	psvDebugScreenFont_current = psvDebugScreenGetFont();
+	psvDebugScreenFont_current->size_w-=1;//narrow character printing
 	printf("Press [L]=%s%s [R]=%s%s\n", wttr[0], wttr[1], rate[0], rate[1]);
 	#ifdef __vita__
 	static char net_mem[1*1024*1024];

--- a/net_libcurl/CMakeLists.txt
+++ b/net_libcurl/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.cpp
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/net_libcurl/src/main.cpp
+++ b/net_libcurl/src/main.cpp
@@ -1,6 +1,6 @@
 #define VITASDK
 
-#include <psp2/io/stat.h>
+#include <psp2/io/stat.h> 
 #include <psp2/sysmodule.h>
 #include <psp2/kernel/processmgr.h>
 #include <psp2/display.h>
@@ -16,7 +16,6 @@
 #include <string.h>
 #include <string>
 
-#define DEBUG_SCREEN_CODE_INCLUDE // needed once inside a C++ project
 #include "debugScreen.h"
 
 #include <curl/curl.h>
@@ -25,7 +24,7 @@
 struct stringcurl {
   char *ptr;
   size_t len;
-};
+}; 
 void init_string(struct stringcurl *s) {
   s->len = 0;
   s->ptr = (char*)malloc(s->len+1);
@@ -63,7 +62,7 @@ void curlDownloadFile(std::string url , std::string file){
 	if(!imageFD){
 		return;
 	}
-
+	
 	CURL *curl;
 	CURLcode res;
 	curl = curl_easy_init();
@@ -87,7 +86,7 @@ void curlDownloadFile(std::string url , std::string file){
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-		// The function that will be used to write the data
+		// The function that will be used to write the data 
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data_to_disk);
 		// The data filedescriptor which will be written to
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &imageFD);
@@ -103,23 +102,23 @@ void curlDownloadFile(std::string url , std::string file){
 		//headerchunk = curl_slist_append(headerchunk, "Host: discordapp.com");  Setting this will lead to errors when trying to download. should be set depending on location : possible : cdn.discordapp.com or images.discordapp.com
 		headerchunk = curl_slist_append(headerchunk, "Content-Length: 0");
 		res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerchunk);
-
-
+		
+		
 		// Perform the request
 		res = curl_easy_perform(curl);
 		int httpresponsecode = 0;
 		curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &httpresponsecode);
-
+		
 		if(res != CURLE_OK){
 			//fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
-
+			
 		}else{
-
+			
 		}
-
-
+		
+		
 	}else{
-
+		
 	}
 
 	// close filedescriptor
@@ -127,13 +126,13 @@ void curlDownloadFile(std::string url , std::string file){
 
 	// cleanup
 	curl_easy_cleanup(curl);
-
+	
 }
 
 void netInit() {
 	psvDebugScreenPrintf("Loading module SCE_SYSMODULE_NET\n");
 	sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
-
+	
 	psvDebugScreenPrintf("Running sceNetInit\n");
 	SceNetInitParam netInitParam;
 	int size = 4*1024*1024;

--- a/net_libcurl/src/main.cpp
+++ b/net_libcurl/src/main.cpp
@@ -1,6 +1,6 @@
 #define VITASDK
 
-#include <psp2/io/stat.h> 
+#include <psp2/io/stat.h>
 #include <psp2/sysmodule.h>
 #include <psp2/kernel/processmgr.h>
 #include <psp2/display.h>
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <string>
 
+#define DEBUG_SCREEN_CODE_INCLUDE // needed once inside a C++ project
 #include "debugScreen.h"
 
 #include <curl/curl.h>
@@ -24,7 +25,7 @@
 struct stringcurl {
   char *ptr;
   size_t len;
-}; 
+};
 void init_string(struct stringcurl *s) {
   s->len = 0;
   s->ptr = (char*)malloc(s->len+1);
@@ -62,7 +63,7 @@ void curlDownloadFile(std::string url , std::string file){
 	if(!imageFD){
 		return;
 	}
-	
+
 	CURL *curl;
 	CURLcode res;
 	curl = curl_easy_init();
@@ -86,7 +87,7 @@ void curlDownloadFile(std::string url , std::string file){
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-		// The function that will be used to write the data 
+		// The function that will be used to write the data
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data_to_disk);
 		// The data filedescriptor which will be written to
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &imageFD);
@@ -102,23 +103,23 @@ void curlDownloadFile(std::string url , std::string file){
 		//headerchunk = curl_slist_append(headerchunk, "Host: discordapp.com");  Setting this will lead to errors when trying to download. should be set depending on location : possible : cdn.discordapp.com or images.discordapp.com
 		headerchunk = curl_slist_append(headerchunk, "Content-Length: 0");
 		res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerchunk);
-		
-		
+
+
 		// Perform the request
 		res = curl_easy_perform(curl);
 		int httpresponsecode = 0;
 		curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &httpresponsecode);
-		
+
 		if(res != CURLE_OK){
 			//fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
-			
+
 		}else{
-			
+
 		}
-		
-		
+
+
 	}else{
-		
+
 	}
 
 	// close filedescriptor
@@ -126,13 +127,13 @@ void curlDownloadFile(std::string url , std::string file){
 
 	// cleanup
 	curl_easy_cleanup(curl);
-	
+
 }
 
 void netInit() {
 	psvDebugScreenPrintf("Loading module SCE_SYSMODULE_NET\n");
 	sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
-	
+
 	psvDebugScreenPrintf("Running sceNetInit\n");
 	SceNetInitParam netInitParam;
 	int size = 4*1024*1024;

--- a/power/CMakeLists.txt
+++ b/power/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/power/src/main.c
+++ b/power/src/main.c
@@ -1,3 +1,6 @@
+#include <stdio.h>
+#include <string.h>
+
 #include <psp2/ctrl.h>
 #include <psp2/kernel/processmgr.h>
 #include <psp2/power.h>

--- a/rtc/CMakeLists.txt
+++ b/rtc/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/socket_ping/CMakeLists.txt
+++ b/socket_ping/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/soloud/CMakeLists.txt
+++ b/soloud/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.cpp
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/soloud/src/main.cpp
+++ b/soloud/src/main.cpp
@@ -5,7 +5,6 @@
 #include <psp2/audioout.h>
 #include <psp2/kernel/processmgr.h>
 
-#define DEBUG_SCREEN_CODE_INCLUDE // needed once inside a C++ project
 #include "debugScreen.h"
 
 #include "soloud.h"

--- a/soloud/src/main.cpp
+++ b/soloud/src/main.cpp
@@ -5,6 +5,7 @@
 #include <psp2/audioout.h>
 #include <psp2/kernel/processmgr.h>
 
+#define DEBUG_SCREEN_CODE_INCLUDE // needed once inside a C++ project
 #include "debugScreen.h"
 
 #include "soloud.h"

--- a/touch/CMakeLists.txt
+++ b/touch/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
   src/main.c
+  ../common/debugScreen.c
 )
 
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
See also https://github.com/vitasdk/samples/issues/50

debugScreen
-----------
* Splitted code and shared definitions into .c and .h file, so it can be used in bigger projects with multiple source files.
  Added custom header file to avoid people messing up the implementation in their projects.
* Fixed CSI 0J command. Enhanced sample debugscreen cases to show the issue.
* Added documentation about CSI commands at top and comments in C functions.
* Implemented ANSI/VTERM/GREYSCALE colors via lookup table for correct colors.
* Implemented color state machine to comply better with ECMA-48 / ISO/IEC 6429:1992 and Graphic Rendition Combination Mode (GRCM) "Cumulative".
* Added CSI 22m. Set standard intensity ("normal" color). Accomplishes CSI 1m and 2m.
* Added CSI 7m and 27m. Enable/disable FG/BG inversion.
* Support 16 storage slots for CSI s and u.
* Enhanced bitmap routines to work also with not byte-aligned glyphs.
  * Enhanced HTML bitmap editor to work also with not byte-aligned glyphs.
* Draw dummy glyph (dotted line in the middle) in correct font size for not available glyphs.
* Added function to get a copy of current color state.
* Added functions to get/set pixel coordinates for custom save storages and custom positioning.
* Added functions to get/set font.
* Added function to scale a font by 2.
* Sanitized macro usage.
* Fixed typos.
* Extended sample "debugscreen" to test more cases and demonstrate new functions:
  * used different background colors to better show CSI J and K commands
  * added font scaling
  * added inversion on/off via CSI 7m and CSI 27m
  * show "dark" white on "bright" black
  * added missing glyph
  * show all colors CSI 30-37/40-47/90-97/100-107 with their RGB code
* Tested nearly all samples, except for network samples.

Sample camera
-------------
* Added missing include <psp2/kernel/processmgr.h> for sceKernelExitProcess().

Sample microphone
-----------------
* Added missing include <string.h> for memset() and memcpy().
* Changed direct access to coordX/Y to CSI sequences.

Sample net_http_bsd
-------------------
* Changed direct access to font to new functions.

Sample power
------------
* Added missing include <stdio.h> for FILE, fopen(), fclose().
* Added missing include <string.h> for memset().
