### PR TITLE
Added stdc++ to linked libs to fix linking errors, see #55 (soloud & hello_cpp_world samples)

### DIFF
--- a/hello_cpp_world/CMakeLists.txt
+++ b/hello_cpp_world/CMakeLists.txt
@@ -56,6 +56,8 @@ add_executable(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   SceLibKernel_stub # this line is only for demonstration. It's not needed as
                     # the most common stubs are automatically included.
+  stdc++
+  pthread
 )
 
 ## Create Vita files

--- a/soloud/CMakeLists.txt
+++ b/soloud/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   soloud
+  stdc++
   pthread
   m
   SceDisplay_stub


### PR DESCRIPTION
 this is a fix for a linking error i was getting when running `make` on soloud and hello_cpp_world samples
and was given the fix in the issue mentioned (#55 )

i don't know the rules for contributing on this project. so i'm sorry if i'm breaking any of them
i'm new to the vita hacking scene so i just thought fixing this error would help new comers (◠‿◠)