### PR TITLE
Remove vita2d from link libs of sdl2 example

### DIFF
--- a/sdl2/redrectangle/CMakeLists.txt
+++ b/sdl2/redrectangle/CMakeLists.txt
@@ -28,7 +28,6 @@ add_executable(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   SDL2
-  vita2d
   SceDisplay_stub
   SceCtrl_stub
   SceAudio_stub


### PR DESCRIPTION
This just removes linking against vita2d in the SDL2 example.

Credit to @isage for letting me know linking vita2d isn't necessary for SDL2 on vita anymore (https://github.com/jtothebell/fake-08/commit/923d24fdb14ed50b4fe2ccee438d8b538351a83e#r47952680)