### PR TITLE
Fix SDL2 sample build with latest vitasdk

### DIFF
--- a/sdl2/redrectangle/CMakeLists.txt
+++ b/sdl2/redrectangle/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   SDL2::SDL2
+  SceAudioIn_stub
 )
 
 vita_create_self(${PROJECT_NAME}.self ${PROJECT_NAME})


### PR DESCRIPTION
after installing the latest vitasdk package available on GitHub, I tried to build the `redrectangle` SDL2 sample and I was getting the following linking error:

```
[ 16%] Linking C executable redrectangle
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: /usr/local/vitasdk/arm-vita-eabi/lib/libSDL2.a(SDL_vitaaudio.c.obj): in function `VITAAUD_OpenCaptureDevice':
(.text+0x38): undefined reference to `sceAudioInOpenPort'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: /usr/local/vitasdk/arm-vita-eabi/lib/libSDL2.a(SDL_vitaaudio.c.obj): in function `VITAAUD_CloseDevice':
(.text+0x2e6): undefined reference to `sceAudioInReleasePort'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: /usr/local/vitasdk/arm-vita-eabi/lib/libSDL2.a(SDL_vitaaudio.c.obj): in function `VITAAUD_CaptureFromDevice':
(.text+0x390): undefined reference to `sceAudioInInput'
collect2: error: ld returned 1 exit status
make[2]: *** [redrectangle] Error 1
make[1]: *** [CMakeFiles/redrectangle.dir/all] Error 2
make: *** [all] Error 2
```

Adding `SceAudioIn_stub` to the CMakeList as proposed in this PR fixes the issue.
