### PR TITLE
Don't call sceKernelExitProcess

### DIFF
--- a/audio/src/main.c
+++ b/audio/src/main.c
@@ -54,7 +54,7 @@ int main(void) {
 			gen=gen_nul;
 		if(ctrl_press.buttons & (SCE_CTRL_CROSS|SCE_CTRL_TRIANGLE|SCE_CTRL_SQUARE|SCE_CTRL_CIRCLE))
 			wave_set(wave_buf,size,gen);
-			
+
 		if(ctrl_press.buttons == SCE_CTRL_RIGHT)
 			freq = MIN(countof(freqs)-1, freq+1);
 		if(ctrl_press.buttons == SCE_CTRL_LEFT)
@@ -81,6 +81,5 @@ int main(void) {
 	}while(ctrl_press.buttons != SCE_CTRL_START);
 
 	sceAudioOutReleasePort(port);
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/camera/src/main.c
+++ b/camera/src/main.c
@@ -44,7 +44,7 @@ int main(void){
 			ctrl_press = ctrl_peek;
 			sceCtrlPeekBufferPositive(0, &ctrl_peek, 1);
 			ctrl_press.buttons = ctrl_peek.buttons & ~ctrl_press.buttons;
-			
+
 			sceCameraSetBrightness(cur_cam, ctrl_press.rx);
 			sceCameraSetContrast(cur_cam, ctrl_press.ry-100);
 			sceCameraSetEV(cur_cam, (ctrl_press.lx-128)/7);//-20...20
@@ -87,6 +87,5 @@ int main(void){
 
 	}while(!(ctrl_press.buttons & SCE_CTRL_START));
 	sceKernelFreeMemBlock(memblock);
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/ctrl/src/main.c
+++ b/ctrl/src/main.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
 	printf("press Select+Start+L+R to stop\n");
 	/* to enable analog sampling */
 	sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
-	
+
 	SceCtrlData ctrl;
 	const char* btn_label[]={"SELECT ","","","START ",
 		"UP ","RIGHT ","DOWN ","LEFT ","L ","R ","","",
@@ -26,6 +26,5 @@ int main(int argc, char *argv[]) {
 		}
 		printf("\e[m Stick:[%3i:%3i][%3i:%3i]\r", ctrl.lx,ctrl.ly, ctrl.rx,ctrl.ry);
 	}while(ctrl.buttons != (SCE_CTRL_START | SCE_CTRL_SELECT | SCE_CTRL_LTRIGGER | SCE_CTRL_RTRIGGER) );
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/debug_print/src/main.c
+++ b/debug_print/src/main.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
 	psvDebugScreenInit();
 
 	printf("Welcome to the psvDebugScreen showcase !\n");
-	
+
 	/* print some bg/fg colors */
 	const char* message = "Let's have some foreground/background colors !\n";
 	int modes[]={3,9,4,10}, c;
@@ -30,6 +30,5 @@ int main(int argc, char *argv[]) {
 	printf("\e[10;20HBye Bye");
 	sceKernelDelayThread(2*1000*1000);
 
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/hello_cpp_world/src/main.cpp
+++ b/hello_cpp_world/src/main.cpp
@@ -16,6 +16,5 @@ int main(int argc, char *argv[]) {
 	}
 	output << std::endl;
 	printf("%s\n", output.str().c_str());
-	sceKernelExitProcess(0);
     return 0;
 }

--- a/hello_world/src/main.c
+++ b/hello_world/src/main.c
@@ -10,8 +10,7 @@
 int main(int argc, char *argv[]) {
 	psvDebugScreenInit();
 	printf("Hello, world!\n");
-	
+
 	sceKernelDelayThread(3*1000000); // Wait for 3 seconds
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/ime/src/main.c
+++ b/ime/src/main.c
@@ -112,6 +112,5 @@ int main(int argc, const char *argv[]) {
 		sceDisplayWaitVblankStart();
 	}
 	gxm_term();
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/json/src/main.cpp
+++ b/json/src/main.cpp
@@ -40,7 +40,7 @@ char* DisplayTestFile()
 
     printf("Input Json Data: \n%s\n", buf);
 
-    return buf;           
+    return buf;
 }
 
 int main()
@@ -62,7 +62,7 @@ int main()
 
     char* buf = DisplayTestFile();
 
-    Value val = Value(); // Creating our Root value. 
+    Value val = Value(); // Creating our Root value.
     Parser::parse(val, "app0:test.json"); // Parse test.json into val.
 
     printf("\nIterating over parsed data\n\n");
@@ -115,7 +115,7 @@ int main()
                     }
                 }
                 break;
-            case ValueType::ObjectValue: 
+            case ValueType::ObjectValue:
                 {
                     printf("Child %d is an Object. Iterating though values.\n\n", i);
                     const Object& obj = v.getObject();
@@ -151,9 +151,9 @@ int main()
     }
 
     String serialized = String();
-    val.serialize(serialized); // Serialize val into parsed. 
+    val.serialize(serialized); // Serialize val into parsed.
     printf("\nSerialized Output Data: \n%s\n", serialized.c_str()); // Display parsed.
-    
+
     int same = strcmp(serialized.c_str(), buf); // Compare the input data to the serialized data.
     if(same < 0 || same > 0)
         printf("The serialized output is not the same as the input.\n");
@@ -178,7 +178,5 @@ int main()
             break;
     }
 
-    sceKernelExitProcess(0);
-    
     return 0;
 }

--- a/microphone/src/main.c
+++ b/microphone/src/main.c
@@ -145,6 +145,5 @@ int main(int argc, char *argv[]){
 
 	free(audioIn);
 	sceAudioInReleasePort(port);
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/motion/src/main.c
+++ b/motion/src/main.c
@@ -10,7 +10,7 @@
 
 int main(){
 	psvDebugScreenInit();
-	
+
 	SceCtrlData ctrl;
 	float threshold;
 	bool is_sampling=false;
@@ -20,7 +20,7 @@ int main(){
 		if(ctrl.buttons & SCE_CTRL_START)
 			break;
 		printf("\e[H");/*reset the cursor position to 0,0*/
-		
+
 		printf("Sampling:%3s (X:ON, O:OFF)\n",is_sampling?"ON":"OFF");
 		if((ctrl.buttons & SCE_CTRL_CROSS) && !is_sampling)
 			is_sampling=(sceMotionStartSampling()==0);
@@ -50,7 +50,7 @@ int main(){
 		/* no need to further if we are not sampling */
 		if(!is_sampling)
 			continue;
-			
+
 		printf("Magnetometer:%3s (L:ON, R:OFF)\n",sceMotionGetMagnetometerState()?"ON":"OFF");
 		if(ctrl.buttons & SCE_CTRL_LTRIGGER)
 			sceMotionMagnetometerOn();
@@ -75,9 +75,9 @@ int main(){
 		printf("NedMatrix.Y  <x:%+1.3f y:%+1.3f z:%+1.3f w:%+1.3f>\n",state.nedMatrix.y.x, state.nedMatrix.y.y, state.nedMatrix.y.z, state.nedMatrix.y.w);
 		printf("NedMatrix.Z  <x:%+1.3f y:%+1.3f z:%+1.3f w:%+1.3f>\n",state.nedMatrix.z.x, state.nedMatrix.z.y, state.nedMatrix.z.z, state.nedMatrix.z.w);
 		printf("NedMatrix.W  <x:%+1.3f y:%+1.3f z:%+1.3f w:%+1.3f>\n",state.nedMatrix.w.x, state.nedMatrix.w.y, state.nedMatrix.w.z, state.nedMatrix.w.w);
-		
+
 		printf("\n");
-		
+
 		SceMotionSensorState sensor;
 		sceMotionGetSensorState(&sensor, 1);
 		printf("SensorCounter:%i                \n",sensor.counter);
@@ -86,9 +86,8 @@ int main(){
 		SceFVector3 basicOrientation;
 		sceMotionGetBasicOrientation(&basicOrientation);
 		printf("basicOrient. <x:%+1.3f y:%+1.3f z:%+1.3f>   \n",basicOrientation.x, basicOrientation.y, basicOrientation.z);
-		
+
 		/*		sceMotionRotateYaw(float radians);*/
 	}
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/net_http/src/main.c
+++ b/net_http/src/main.c
@@ -19,7 +19,7 @@
 void netInit() {
 	psvDebugScreenPrintf("Loading module SCE_SYSMODULE_NET\n");
 	sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
-	
+
 	psvDebugScreenPrintf("Running sceNetInit\n");
 	SceNetInitParam netInitParam;
 	int size = 1*1024*1024;
@@ -117,6 +117,5 @@ int main(int argc, char *argv[]) {
 	psvDebugScreenPrintf("This app will close in 10 seconds!\n");
 	sceKernelDelayThread(10*1000*1000);
 
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/net_https/src/main.c
+++ b/net_https/src/main.c
@@ -232,7 +232,5 @@ int main(int argc, char **argp){
 	sceSysmoduleUnloadModuleInternal(SCE_SYSMODULE_INTERNAL_PAF);
 
 	sceKernelDelayThread(40000);
-	sceKernelExitProcess(0);
-
 	return 0;
 }

--- a/net_libcurl/src/main.cpp
+++ b/net_libcurl/src/main.cpp
@@ -1,6 +1,6 @@
 #define VITASDK
 
-#include <psp2/io/stat.h> 
+#include <psp2/io/stat.h>
 #include <psp2/sysmodule.h>
 #include <psp2/kernel/processmgr.h>
 #include <psp2/display.h>
@@ -24,7 +24,7 @@
 struct stringcurl {
   char *ptr;
   size_t len;
-}; 
+};
 void init_string(struct stringcurl *s) {
   s->len = 0;
   s->ptr = (char*)malloc(s->len+1);
@@ -62,7 +62,7 @@ void curlDownloadFile(std::string url , std::string file){
 	if(!imageFD){
 		return;
 	}
-	
+
 	CURL *curl;
 	CURLcode res;
 	curl = curl_easy_init();
@@ -86,7 +86,7 @@ void curlDownloadFile(std::string url , std::string file){
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-		// The function that will be used to write the data 
+		// The function that will be used to write the data
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data_to_disk);
 		// The data filedescriptor which will be written to
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &imageFD);
@@ -102,23 +102,23 @@ void curlDownloadFile(std::string url , std::string file){
 		//headerchunk = curl_slist_append(headerchunk, "Host: discordapp.com");  Setting this will lead to errors when trying to download. should be set depending on location : possible : cdn.discordapp.com or images.discordapp.com
 		headerchunk = curl_slist_append(headerchunk, "Content-Length: 0");
 		res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerchunk);
-		
-		
+
+
 		// Perform the request
 		res = curl_easy_perform(curl);
 		int httpresponsecode = 0;
 		curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &httpresponsecode);
-		
+
 		if(res != CURLE_OK){
 			//fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
-			
+
 		}else{
-			
+
 		}
-		
-		
+
+
 	}else{
-		
+
 	}
 
 	// close filedescriptor
@@ -126,13 +126,13 @@ void curlDownloadFile(std::string url , std::string file){
 
 	// cleanup
 	curl_easy_cleanup(curl);
-	
+
 }
 
 void netInit() {
 	psvDebugScreenPrintf("Loading module SCE_SYSMODULE_NET\n");
 	sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
-	
+
 	psvDebugScreenPrintf("Running sceNetInit\n");
 	SceNetInitParam netInitParam;
 	int size = 4*1024*1024;
@@ -193,6 +193,5 @@ int main(int argc, char *argv[]) {
 	psvDebugScreenPrintf("This app will close in 10 seconds!\n");
 	sceKernelDelayThread(10*1000*1000);
 
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/power/src/main.c
+++ b/power/src/main.c
@@ -20,7 +20,7 @@ int powerCallback(int notifyId, int notifyCount, int powerInfo, void *common) {
 
 	SceDateTime time;
 	sceRtcGetCurrentClockLocalTime(&time);
-	printf("%04d/%02d/%02d %02d:%02d:%02d:%05d notifyId %i, notifyCount %i, powerInfo 0x%08X\n", 
+	printf("%04d/%02d/%02d %02d:%02d:%02d:%05d notifyId %i, notifyCount %i, powerInfo 0x%08X\n",
 		sceRtcGetYear(&time), sceRtcGetMonth(&time), sceRtcGetDay(&time),
 		sceRtcGetHour(&time), sceRtcGetMinute(&time), sceRtcGetSecond(&time), sceRtcGetMicrosecond(&time),
 		notifyId, notifyCount, powerInfo);
@@ -59,14 +59,14 @@ int setupCallbacks(void) {
 }
 
 /* main routine */
-int main(int argc, char *argv[]) 
-{	
+int main(int argc, char *argv[])
+{
 	SceCtrlData pad;
 	int i = 0;
 	int batteryLifeTime = 0;
 
 	psvDebugScreenInit();
-	
+
 	printf("PS Vita Power Sample v0.1\n\n");
 	printf("External power: %s\n", scePowerIsPowerOnline()? "yes" : "no ");
 	printf("Low charge: %s\n", scePowerIsLowBattery()? "yes" : "no ");
@@ -85,12 +85,10 @@ int main(int argc, char *argv[])
 	{
 		memset(&pad, 0, sizeof(pad));
 		sceCtrlPeekBufferPositive(0, &pad, 1);
-		
+
 		if (pad.buttons & SCE_CTRL_START)
 			break;
 	}
-
-	sceKernelExitProcess(0);
 
 	return 0;
 }

--- a/pretty_livearea/src/main.c
+++ b/pretty_livearea/src/main.c
@@ -3,6 +3,5 @@
 
 int main(int argc, char *argv[]) {
 	printf("Hello, pretty world!\n");
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/prx_loader/main.c
+++ b/prx_loader/main.c
@@ -1,5 +1,5 @@
 #include <psp2/kernel/processmgr.h>
-#include <psp2/kernel/modulemgr.h> 
+#include <psp2/kernel/modulemgr.h>
 #include <psp2/io/fcntl.h>
 #include <psp2/ctrl.h>
 
@@ -68,6 +68,5 @@ int main(int argc, char *argv[]) {
 				status = mi.module_stop(0,"but not from ModuleMgr");
 		}
 	}
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/rtc/src/main.c
+++ b/rtc/src/main.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
 	printf("Tick Resolution = %i\n", sceRtcGetTickResolution());
 
 	SceRtcTick current, network, utc, local;
-	
+
 	printf("     Current %s:%llu\n", sceRtcGetCurrentTick       (&current      )?"FAIL":"", current.tick);
 	printf("     Network %s:%llu\n", sceRtcGetCurrentNetworkTick(&network      )?"FAIL":"", network.tick);
 	printf("     Loc2UTC %s:%llu\n", sceRtcConvertLocalTimeToUtc(&current, &utc)?"FAIL":"", utc.tick);
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
 	printf("     Loc %c UTC\n","<=>"[sceRtcCompareTick(&current, &utc)+1]);
 	printf("     UTC %c Loc\n","<=>"[sceRtcCompareTick(&utc, &current)+1]);
 	printf("     UTC %c UTC\n","<=>"[sceRtcCompareTick(&utc, &utc    )+1]);
-	
+
 	SceRtcTick add1000, us1000, sec120, min120, hour48, days32, week64, month13, year1000;
 	printf("      T+1000 %s:%llu\n", sceRtcTickAddTicks       (&add1000, &current, 1000)?"FAIL":"", add1000.tick);
 	printf("     Us+1000 %s:%llu\n", sceRtcTickAddMicroseconds(&us1000,  &current, 1000)?"FAIL":"", us1000.tick);
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
 	printf("RFC3339 + 2  %s:%s\n", sceRtcFormatRFC3339         (rfc3339_12, &utc, -120)?"FAIL":"", rfc3339_12);
 	printf("RFC2822local %s:%s\n", sceRtcFormatRFC2822LocalTime(rfc2822_loc,&utc      )?"FAIL":"", rfc2822_loc);
 	printf("RFC2822 - 2  %s:%s\n", sceRtcFormatRFC2822         (rfc2822_12, &utc, +120)?"FAIL":"", rfc2822_12);
-	
+
 	const char*rfc_ex1 = "2002-10-02T10:00:00-05:00";
 	const char*rfc_ex2 = "2002-10-02T15:00:00Z";
 	const char*rfc_ex3 = "2002-10-02T15:00:00.05Z";
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
 	printf("datetime_2   %s:%-26s->%llu\n",sceRtcParseDateTime(&parsedDate_ex2, datetime_ex2)?"FAIL":"", datetime_ex2, parsedDate_ex2);
 	printf("datetime_3   %s:%-26s->%llu\n",sceRtcParseDateTime(&parsedDate_ex3, datetime_ex3)?"FAIL":"", datetime_ex3, parsedDate_ex3);
 
-	/* TODO 
+	/* TODO
 	sceRtcSetTime_t(&time, time_t iTime);
 	sceRtcSetTime64_t(&time, SceUInt64 ullTime);
 	sceRtcGetTime_t(const &time, time_t *piTime);
@@ -100,6 +100,5 @@ int main(int argc, char *argv[]) {
 		sceKernelDelayThread(1000*1000);
 	}
 
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/sdl2/redrectangle/src/main.c
+++ b/sdl2/redrectangle/src/main.c
@@ -10,15 +10,15 @@ enum {
 SDL_Window    * gWindow   = NULL;
 SDL_Renderer  * gRenderer = NULL;
 
-SDL_Rect fillRect = { SCREEN_WIDTH  / 4, 
-		      SCREEN_HEIGHT / 4, 
-		      SCREEN_WIDTH  / 2, 
-		      SCREEN_HEIGHT / 2 
+SDL_Rect fillRect = { SCREEN_WIDTH  / 4,
+		      SCREEN_HEIGHT / 4,
+		      SCREEN_WIDTH  / 2,
+		      SCREEN_HEIGHT / 2
 };
 
 
 
-int main(int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
   if( SDL_Init( SDL_INIT_VIDEO ) < 0 )
       return -1;
@@ -37,8 +37,7 @@ int main(int argc, char *argv[])
   SDL_DestroyWindow( gWindow );
   gWindow = NULL;
   gRenderer = NULL;
-  
+
   SDL_Quit();
-  sceKernelExitProcess(0);
   return 0;
 }

--- a/soloud/src/main.cpp
+++ b/soloud/src/main.cpp
@@ -35,7 +35,5 @@ int main(void) {
 		sceKernelDelayThread(1000 * 1000);
 	}
 
-
-	sceKernelExitProcess(0);
 	return 0;
 }

--- a/touch/src/main.c
+++ b/touch/src/main.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 	sceTouchSetSamplingState(SCE_TOUCH_PORT_BACK, 1);
 	sceTouchEnableTouchForce(SCE_TOUCH_PORT_FRONT);
 	sceTouchEnableTouchForce(SCE_TOUCH_PORT_BACK);
-	
+
 	SceTouchData touch_old[SCE_TOUCH_PORT_MAX_NUM];
 	SceTouchData touch[SCE_TOUCH_PORT_MAX_NUM];
 	while (1) {
@@ -42,6 +42,5 @@ int main(int argc, char *argv[]) {
 		  && (touch_old[SCE_TOUCH_PORT_FRONT].report[0].y < 1000))
 		break;
 	}
-	sceKernelExitProcess(0);
 	return 0;
 }


### PR DESCRIPTION
Just return from `main()` and newlib will take care of doing some cleanup and then call `sceKernelExitProcess`.

`__attribute__((destructor))`-marked functions would not be called otherwise.