### PR TITLE
Differentiate sdl2 and sdl3 redrectangle projects

### DIFF
--- a/sdl2/redrectangle/CMakeLists.txt
+++ b/sdl2/redrectangle/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   endif()
 endif()
 
-project(redrectangle)
+project(sdl2_redrectangle)
 include("${VITASDK}/share/vita.cmake" REQUIRED)
 
 find_package(SDL2 REQUIRED)

--- a/sdl3/redrectangle/CMakeLists.txt
+++ b/sdl3/redrectangle/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   endif()
 endif()
 
-project(redrectangle)
+project(sdl3_redrectangle)
 include("${VITASDK}/share/vita.cmake" REQUIRED)
 
 find_package(SDL3 REQUIRED)


### PR DESCRIPTION
Fix these errors when configuring CMake using `cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake`:
```
CMake Error at sdl3/redrectangle/CMakeLists.txt:27 (add_executable):
  add_executable cannot create target "redrectangle" because another target                                                                                                                                                                                                                                         
  with the same name already exists.  The existing target is an executable                                                                                                                                                                                                                                          
  created in source directory                                                                                                                                                                                                                                                                                       
  "/home/pvezien/CLionProjects/samples/sdl2/redrectangle".  See documentation                                                                                                                                                                                                                                       
  for policy CMP0002 for more details.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
CMake Error at /usr/local/vitasdk/share/vita.cmake:184 (add_custom_target):
  add_custom_target cannot create target "redrectangle-velf" because another                                                                                                                                                                                                                                        
  target with the same name already exists.  The existing target is a custom                                                                                                                                                                                                                                        
  target created in source directory                                                                                                                                                                                                                                                                                
  "/home/pvezien/CLionProjects/samples/sdl2/redrectangle".  See documentation                                                                                                                                                                                                                                       
  for policy CMP0002 for more details.                                                                                                                                                                                                                                                                              
Call Stack (most recent call first):                                                                                                                                                                                                                                                                                
  sdl3/redrectangle/CMakeLists.txt:35 (vita_create_self)                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
CMake Error at /usr/local/vitasdk/share/vita.cmake:222 (add_custom_target):
  add_custom_target cannot create target "redrectangle.self-self" because                                                                                                                                                                                                                                           
  another target with the same name already exists.  The existing target is a                                                                                                                                                                                                                                       
  custom target created in source directory                                                                                                                                                                                                                                                                         
  "/home/pvezien/CLionProjects/samples/sdl2/redrectangle".  See documentation                                                                                                                                                                                                                                       
  for policy CMP0002 for more details.                                                                                                                                                                                                                                                                              
Call Stack (most recent call first):                                                                                                                                                                                                                                                                                
  sdl3/redrectangle/CMakeLists.txt:35 (vita_create_self)                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
CMake Error at /usr/local/vitasdk/share/vita.cmake:434 (add_custom_target):
  add_custom_target cannot create target "redrectangle.vpk-vpk" because                                                                                                                                                                                                                                             
  another target with the same name already exists.  The existing target is a                                                                                                                                                                                                                                       
  custom target created in source directory                                                                                                                                                                                                                                                                         
  "/home/pvezien/CLionProjects/samples/sdl2/redrectangle".  See documentation                                                                                                                                                                                                                                       
  for policy CMP0002 for more details.                                                                                                                                                                                                                                                                              
Call Stack (most recent call first):                                                                                                                                                                                                                                                                                
  sdl3/redrectangle/CMakeLists.txt:36 (vita_create_vpk)                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
-- Configuring incomplete, errors occurred!
```